### PR TITLE
move examples code to lib

### DIFF
--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -16,7 +16,5 @@ license = "MIT/Apache-2.0"
 failure = "0.1"
 failure_derive = "0.1"
 foundationdb-sys = { version = "0.0.2", path = "../foundationdb-sys" }
-lazy_static = "1.0"
-
-[dev-dependencies]
 futures = "0.1"
+lazy_static = "1.0"

--- a/foundationdb/examples/hello.rs
+++ b/foundationdb/examples/hello.rs
@@ -38,8 +38,17 @@ fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
     Box::new(fut)
 }
 
+#[cfg(target_os = "linux")]
+fn default_config_path() -> &'static str {
+    "/etc/foundationdb/fdb.cluster"
+}
+#[cfg(target_os = "macos")]
+fn default_config_path() -> &'static str {
+    "/usr/local/etc/foundationdb/fdb.cluster"
+}
+
 fn example_get_multi() -> Box<Future<Item = (), Error = FdbError>> {
-    let fut = Cluster::new("/etc/foundationdb/fdb.cluster")
+    let fut = Cluster::new(default_config_path())
         .and_then(|cluster| cluster.create_database())
         .and_then(|db| result(db.create_trx()))
         .and_then(|trx| {

--- a/foundationdb/examples/hello.rs
+++ b/foundationdb/examples/hello.rs
@@ -18,7 +18,7 @@ fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
             trx.set(b"hello", b"world");
             trx.commit()
         })
-        .and_then(|db| result(db.create_trx()))
+        .and_then(|trx| result(trx.database().create_trx()))
         .and_then(|trx| trx.get(b"hello"))
         .and_then(|res| {
             let val = res.value();
@@ -28,7 +28,7 @@ fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
             trx.clear(b"hello");
             trx.commit()
         })
-        .and_then(|db| result(db.create_trx()))
+        .and_then(|trx| result(trx.database().create_trx()))
         .and_then(|trx| trx.get(b"hello"))
         .and_then(|res| {
             eprintln!("value: {:?}", res.value());

--- a/foundationdb/examples/hello.rs
+++ b/foundationdb/examples/hello.rs
@@ -2,352 +2,16 @@ extern crate foundationdb;
 extern crate foundationdb_sys;
 extern crate futures;
 
-use std::sync::Arc;
-
-use foundationdb::error;
-use foundationdb_sys as fdb;
+use foundationdb::*;
+use foundationdb_sys as fdb_sys;
 
 use futures::future::*;
-use futures::Async;
 
 use error::FdbError;
 
-type Result<T> = std::result::Result<T, FdbError>;
-
-#[derive(Clone)]
-struct FdbCluster {
-    inner: Arc<FdbClusterInner>,
-}
-impl FdbCluster {
-    fn new(path: &str) -> FdbClusterGet {
-        let path_str = std::ffi::CString::new(path).unwrap();
-        let f = unsafe { fdb::fdb_create_cluster(path_str.as_ptr()) };
-        FdbClusterGet {
-            inner: FdbFuture::new(f),
-        }
-    }
-
-    //TODO: impl Future
-    fn create_database(&self) -> Box<Future<Item = FdbDatabase, Error = FdbError>> {
-        let f = unsafe {
-            let f_db = fdb::fdb_cluster_create_database(self.inner.inner, b"DB" as *const _, 2);
-            let cluster = self.clone();
-            FdbFuture::new(f_db)
-                .and_then(|f| f.get_database())
-                .map(|db| FdbDatabase {
-                    cluster,
-                    inner: Arc::new(FdbDatabaseInner::new(db)),
-                })
-        };
-        Box::new(f)
-    }
-}
-
-struct FdbClusterGet {
-    inner: FdbFuture,
-}
-impl Future for FdbClusterGet {
-    type Item = FdbCluster;
-    type Error = FdbError;
-
-    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
-        match self.inner.poll() {
-            Ok(Async::Ready(r)) => match unsafe { r.get_cluster() } {
-                Ok(c) => Ok(Async::Ready(FdbCluster {
-                    inner: Arc::new(FdbClusterInner::new(c)),
-                })),
-                Err(e) => Err(e),
-            },
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-struct FdbClusterInner {
-    inner: *mut fdb::FDBCluster,
-}
-impl FdbClusterInner {
-    fn new(inner: *mut fdb::FDBCluster) -> Self {
-        Self { inner }
-    }
-}
-impl Drop for FdbClusterInner {
-    fn drop(&mut self) {
-        unsafe {
-            fdb::fdb_cluster_destroy(self.inner);
-        }
-    }
-}
-
-#[derive(Clone)]
-struct FdbDatabase {
-    cluster: FdbCluster,
-    inner: Arc<FdbDatabaseInner>,
-}
-impl FdbDatabase {
-    fn create_trx(&self) -> Result<FdbTransaction> {
-        unsafe {
-            let mut trx: *mut fdb::FDBTransaction = std::ptr::null_mut();
-            let err = fdb::fdb_database_create_transaction(self.inner.inner, &mut trx as *mut _);
-            if err != 0 {
-                return Err(FdbError::from(err));
-            }
-            Ok(FdbTransaction {
-                database: self.clone(),
-                inner: Arc::new(FdbTransactionInner::new(trx)),
-            })
-        }
-    }
-}
-
-struct FdbDatabaseInner {
-    inner: *mut fdb::FDBDatabase,
-}
-impl FdbDatabaseInner {
-    fn new(inner: *mut fdb::FDBDatabase) -> Self {
-        Self { inner }
-    }
-}
-impl Drop for FdbDatabaseInner {
-    fn drop(&mut self) {
-        unsafe {
-            fdb::fdb_database_destroy(self.inner);
-        }
-    }
-}
-
-#[derive(Clone)]
-struct FdbTransaction {
-    database: FdbDatabase,
-    inner: Arc<FdbTransactionInner>,
-}
-impl FdbTransaction {
-    pub fn database(&self) -> FdbDatabase {
-        self.database.clone()
-    }
-
-    fn set(&self, key: &[u8], value: &[u8]) {
-        let trx = self.inner.inner;
-        unsafe {
-            fdb::fdb_transaction_set(
-                trx,
-                key.as_ptr(),
-                key.len() as i32,
-                value.as_ptr(),
-                value.len() as i32,
-            )
-        }
-    }
-
-    fn clear(&self, key: &[u8]) {
-        let trx = self.inner.inner;
-        unsafe { fdb::fdb_transaction_clear(trx, key.as_ptr(), key.len() as i32) }
-    }
-
-    fn get(&self, key: &[u8]) -> FdbTrxGet {
-        let trx = self.inner.inner;
-
-        let f =
-            unsafe { fdb::fdb_transaction_get(trx, key.as_ptr() as *const _, key.len() as i32, 0) };
-        let f = FdbFuture::new(f);
-        FdbTrxGet {
-            trx: self.clone(),
-            inner: f,
-        }
-    }
-
-    fn commit(self) -> FdbTrxCommit {
-        let trx = self.inner.inner;
-
-        let f = unsafe { fdb::fdb_transaction_commit(trx) };
-        let f = FdbFuture::new(f);
-        FdbTrxCommit {
-            trx: self,
-            inner: f,
-        }
-    }
-}
-
-struct FdbTransactionInner {
-    inner: *mut fdb::FDBTransaction,
-}
-impl FdbTransactionInner {
-    fn new(inner: *mut fdb::FDBTransaction) -> Self {
-        Self { inner }
-    }
-}
-impl Drop for FdbTransactionInner {
-    fn drop(&mut self) {
-        unsafe {
-            fdb::fdb_transaction_destroy(self.inner);
-        }
-    }
-}
-
-struct FdbGetResult {
-    trx: FdbTransaction,
-    inner: FdbFutureResult,
-}
-impl FdbGetResult {
-    pub fn transaction(&self) -> FdbTransaction {
-        self.trx.clone()
-    }
-    pub fn value(&self) -> Result<Option<&[u8]>> {
-        self.inner.get_value()
-    }
-}
-
-struct FdbTrxGet {
-    trx: FdbTransaction,
-    inner: FdbFuture,
-}
-impl Future for FdbTrxGet {
-    type Item = FdbGetResult;
-    type Error = FdbError;
-
-    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
-        match self.inner.poll() {
-            Ok(Async::Ready(r)) => Ok(Async::Ready(FdbGetResult {
-                trx: self.trx.clone(),
-                inner: r,
-            })),
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-struct FdbTrxCommit {
-    trx: FdbTransaction,
-    inner: FdbFuture,
-}
-impl Future for FdbTrxCommit {
-    type Item = FdbDatabase;
-    type Error = FdbError;
-
-    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
-        match self.inner.poll() {
-            Ok(Async::Ready(_r)) => Ok(Async::Ready(self.trx.database.clone())),
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-struct FdbFutureResult {
-    f: *mut fdb::FDBFuture,
-}
-impl FdbFutureResult {
-    fn new(f: *mut fdb::FDBFuture) -> Self {
-        Self { f }
-    }
-
-    unsafe fn get_cluster(&self) -> Result<*mut fdb::FDBCluster> {
-        let mut v: *mut fdb::FDBCluster = std::ptr::null_mut();
-        let err = fdb::fdb_future_get_cluster(self.f, &mut v as *mut _);
-        if err != 0 {
-            return Err(FdbError::from(err));
-        }
-        Ok(v)
-    }
-
-    unsafe fn get_database(&self) -> Result<*mut fdb::FDBDatabase> {
-        let mut v: *mut fdb::FDBDatabase = std::ptr::null_mut();
-        let err = fdb::fdb_future_get_database(self.f, &mut v as *mut _);
-        if err != 0 {
-            return Err(FdbError::from(err));
-        }
-        Ok(v)
-    }
-
-    fn get_value<'a>(&'a self) -> Result<Option<&'a [u8]>> {
-        let mut present = 0;
-        let mut out_value = std::ptr::null();
-        let mut out_len = 0;
-        let err = unsafe {
-            fdb::fdb_future_get_value(
-                self.f,
-                &mut present as *mut _,
-                &mut out_value as *mut _,
-                &mut out_len as *mut _,
-            )
-        };
-        if err != 0 {
-            return Err(FdbError::from(err));
-        }
-        if present == 0 {
-            return Ok(None);
-        }
-        let slice = unsafe { std::slice::from_raw_parts(out_value, out_len as usize) };
-        Ok(Some(slice))
-    }
-}
-
-impl Drop for FdbFutureResult {
-    fn drop(&mut self) {
-        unsafe { fdb::fdb_future_destroy(self.f) }
-    }
-}
-
-struct FdbFuture {
-    //
-    f: *mut fdb::FDBFuture,
-    task: Option<Box<futures::task::Task>>,
-}
-
-impl FdbFuture {
-    fn new(f: *mut fdb::FDBFuture) -> Self {
-        Self { f, task: None }
-    }
-}
-
-impl futures::Future for FdbFuture {
-    type Item = FdbFutureResult;
-    type Error = FdbError;
-
-    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
-        if self.task.is_none() {
-            let task = futures::task::current();
-            let task = Box::new(task);
-            let task_ptr = task.as_ref() as *const _;
-            unsafe {
-                fdb::fdb_future_set_callback(self.f, Some(fdb_future_callback), task_ptr as *mut _);
-            }
-            self.task = Some(task);
-
-            return Ok(Async::NotReady);
-        }
-
-        let ready = unsafe { fdb::fdb_future_is_ready(self.f) };
-        if ready == 0 {
-            return Ok(Async::NotReady);
-        }
-
-        let err = unsafe { fdb::fdb_future_get_error(self.f) };
-        if err != 0 {
-            return Err(FdbError::from(err));
-        }
-
-        let g = FdbFutureResult::new(self.f);
-        self.f = std::ptr::null_mut();
-
-        Ok(Async::Ready(g))
-    }
-}
-
-extern "C" fn fdb_future_callback(
-    _f: *mut fdb::FDBFuture,
-    callback_parameter: *mut ::std::os::raw::c_void,
-) {
-    let task: *const futures::task::Task = callback_parameter as *const _;
-    let task: &futures::task::Task = unsafe { std::mem::transmute(task) };
-    task.notify();
-}
-
 //TODO: impl Future
 fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
-    let fut = FdbCluster::new("/etc/foundationdb/fdb.cluster")
+    let fut = Cluster::new("/etc/foundationdb/fdb.cluster")
         .and_then(|cluster| cluster.create_database())
         .and_then(|db| result(db.create_trx()))
         .and_then(|trx| {
@@ -375,7 +39,7 @@ fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
 }
 
 fn example_get_multi() -> Box<Future<Item = (), Error = FdbError>> {
-    let fut = FdbCluster::new("/etc/foundationdb/fdb.cluster")
+    let fut = Cluster::new("/etc/foundationdb/fdb.cluster")
         .and_then(|cluster| cluster.create_database())
         .and_then(|db| result(db.create_trx()))
         .and_then(|trx| {
@@ -396,19 +60,20 @@ fn example_get_multi() -> Box<Future<Item = (), Error = FdbError>> {
 
 fn main() {
     let handle = unsafe {
-        let version = fdb::fdb_get_max_api_version();
-        let err = fdb::fdb_select_api_version_impl(version, version);
+        //TODO: switch to safe API
+        let version = fdb_sys::fdb_get_max_api_version();
+        let err = fdb_sys::fdb_select_api_version_impl(version, version);
         if err != 0 {
             panic!("fdb_select_api_version: {:?}", FdbError::from(err));
         }
 
-        let err = fdb::fdb_setup_network();
+        let err = fdb_sys::fdb_setup_network();
         if err != 0 {
             panic!("fdb_setup_network: {:?}", FdbError::from(err));
         }
 
         std::thread::spawn(|| {
-            let err = fdb::fdb_run_network();
+            let err = fdb_sys::fdb_run_network();
             if err != 0 {
                 panic!("fdb_run_network: {:?}", FdbError::from(err));
             }
@@ -419,7 +84,8 @@ fn main() {
     example_get_multi().wait().expect("failed to run");
 
     unsafe {
-        fdb::fdb_stop_network();
+        //TODO: switch to safe API
+        fdb_sys::fdb_stop_network();
     }
     handle.join().expect("failed to join fdb thread");
 }

--- a/foundationdb/src/cluster.rs
+++ b/foundationdb/src/cluster.rs
@@ -54,6 +54,7 @@ impl Future for ClusterGet {
     }
 }
 
+//TODO: should check if `fdb::FDBCluster` is thread-safe.
 struct ClusterInner {
     inner: *mut fdb::FDBCluster,
 }

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -1,0 +1,45 @@
+use foundationdb_sys as fdb;
+use std;
+use std::sync::Arc;
+
+use cluster::*;
+use error::*;
+use transaction::*;
+
+#[derive(Clone)]
+pub struct Database {
+    cluster: Cluster,
+    inner: Arc<DatabaseInner>,
+}
+impl Database {
+    pub(crate) fn new(cluster: Cluster, db: *mut fdb::FDBDatabase) -> Self {
+        let inner = Arc::new(DatabaseInner::new(db));
+        Self { cluster, inner }
+    }
+    pub fn create_trx(&self) -> Result<Transaction> {
+        unsafe {
+            let mut trx: *mut fdb::FDBTransaction = std::ptr::null_mut();
+            let err = fdb::fdb_database_create_transaction(self.inner.inner, &mut trx as *mut _);
+            if err != 0 {
+                return Err(FdbError::from(err));
+            }
+            Ok(Transaction::new(self.clone(), trx))
+        }
+    }
+}
+
+struct DatabaseInner {
+    inner: *mut fdb::FDBDatabase,
+}
+impl DatabaseInner {
+    fn new(inner: *mut fdb::FDBDatabase) -> Self {
+        Self { inner }
+    }
+}
+impl Drop for DatabaseInner {
+    fn drop(&mut self) {
+        unsafe {
+            fdb::fdb_database_destroy(self.inner);
+        }
+    }
+}

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -1,4 +1,5 @@
 use options;
+use std;
 use std::ffi::CStr;
 
 use foundationdb_sys as fdb;
@@ -9,6 +10,8 @@ pub struct FdbError {
     error_code: i32,
     error_str: &'static str,
 }
+
+pub type Result<T> = std::result::Result<T, FdbError>;
 
 impl FdbError {
     pub fn from(error_code: fdb::fdb_error_t) -> Self {

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -1,0 +1,117 @@
+use std;
+
+use foundationdb_sys as fdb;
+use futures;
+use futures::Async;
+
+use error::{FdbError, Result};
+
+pub struct FdbFuture {
+    //
+    f: *mut fdb::FDBFuture,
+    task: Option<Box<futures::task::Task>>,
+}
+
+impl FdbFuture {
+    pub(crate) fn new(f: *mut fdb::FDBFuture) -> Self {
+        Self { f, task: None }
+    }
+}
+
+impl futures::Future for FdbFuture {
+    type Item = FdbFutureResult;
+    type Error = FdbError;
+
+    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
+        if self.task.is_none() {
+            let task = futures::task::current();
+            let task = Box::new(task);
+            let task_ptr = task.as_ref() as *const _;
+            unsafe {
+                fdb::fdb_future_set_callback(self.f, Some(fdb_future_callback), task_ptr as *mut _);
+            }
+            self.task = Some(task);
+
+            return Ok(Async::NotReady);
+        }
+
+        let ready = unsafe { fdb::fdb_future_is_ready(self.f) };
+        if ready == 0 {
+            return Ok(Async::NotReady);
+        }
+
+        let err = unsafe { fdb::fdb_future_get_error(self.f) };
+        if err != 0 {
+            return Err(FdbError::from(err));
+        }
+
+        let g = FdbFutureResult::new(self.f);
+        self.f = std::ptr::null_mut();
+
+        Ok(Async::Ready(g))
+    }
+}
+
+extern "C" fn fdb_future_callback(
+    _f: *mut fdb::FDBFuture,
+    callback_parameter: *mut ::std::os::raw::c_void,
+) {
+    let task: *const futures::task::Task = callback_parameter as *const _;
+    let task: &futures::task::Task = unsafe { std::mem::transmute(task) };
+    task.notify();
+}
+
+pub struct FdbFutureResult {
+    f: *mut fdb::FDBFuture,
+}
+impl FdbFutureResult {
+    pub(crate) fn new(f: *mut fdb::FDBFuture) -> Self {
+        Self { f }
+    }
+
+    pub(crate) unsafe fn get_cluster(&self) -> Result<*mut fdb::FDBCluster> {
+        let mut v: *mut fdb::FDBCluster = std::ptr::null_mut();
+        let err = fdb::fdb_future_get_cluster(self.f, &mut v as *mut _);
+        if err != 0 {
+            return Err(FdbError::from(err));
+        }
+        Ok(v)
+    }
+
+    pub(crate) unsafe fn get_database(&self) -> Result<*mut fdb::FDBDatabase> {
+        let mut v: *mut fdb::FDBDatabase = std::ptr::null_mut();
+        let err = fdb::fdb_future_get_database(self.f, &mut v as *mut _);
+        if err != 0 {
+            return Err(FdbError::from(err));
+        }
+        Ok(v)
+    }
+
+    pub(crate) fn get_value<'a>(&'a self) -> Result<Option<&'a [u8]>> {
+        let mut present = 0;
+        let mut out_value = std::ptr::null();
+        let mut out_len = 0;
+        let err = unsafe {
+            fdb::fdb_future_get_value(
+                self.f,
+                &mut present as *mut _,
+                &mut out_value as *mut _,
+                &mut out_len as *mut _,
+            )
+        };
+        if err != 0 {
+            return Err(FdbError::from(err));
+        }
+        if present == 0 {
+            return Ok(None);
+        }
+        let slice = unsafe { std::slice::from_raw_parts(out_value, out_len as usize) };
+        Ok(Some(slice))
+    }
+}
+
+impl Drop for FdbFutureResult {
+    fn drop(&mut self) {
+        unsafe { fdb::fdb_future_destroy(self.f) }
+    }
+}

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -5,8 +5,18 @@ extern crate failure_derive;
 extern crate foundationdb_sys;
 #[macro_use]
 extern crate lazy_static;
+extern crate futures;
 
+pub mod cluster;
 pub mod context;
+pub mod database;
 pub mod error;
+pub mod future;
 pub mod network;
 pub mod options;
+pub mod transaction;
+
+//move to prelude?
+pub use cluster::Cluster;
+pub use database::Database;
+pub use transaction::Transaction;

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -118,7 +118,6 @@ pub struct TrxCommit {
     inner: FdbFuture,
 }
 impl Future for TrxCommit {
-    //should be ()?
     type Item = Transaction;
     type Error = FdbError;
 

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -1,0 +1,132 @@
+use foundationdb_sys as fdb;
+use futures::{Async, Future};
+use std;
+use std::sync::Arc;
+
+use database::*;
+use error::*;
+use future::*;
+
+#[derive(Clone)]
+pub struct Transaction {
+    database: Database,
+    inner: Arc<TransactionInner>,
+}
+impl Transaction {
+    pub(crate) fn new(database: Database, trx: *mut fdb::FDBTransaction) -> Self {
+        let inner = Arc::new(TransactionInner::new(trx));
+        Self { database, inner }
+    }
+
+    pub fn database(&self) -> Database {
+        self.database.clone()
+    }
+
+    pub fn set(&self, key: &[u8], value: &[u8]) {
+        let trx = self.inner.inner;
+        unsafe {
+            fdb::fdb_transaction_set(
+                trx,
+                key.as_ptr(),
+                key.len() as i32,
+                value.as_ptr(),
+                value.len() as i32,
+            )
+        }
+    }
+
+    pub fn clear(&self, key: &[u8]) {
+        let trx = self.inner.inner;
+        unsafe { fdb::fdb_transaction_clear(trx, key.as_ptr(), key.len() as i32) }
+    }
+
+    pub fn get(&self, key: &[u8]) -> TrxGet {
+        let trx = self.inner.inner;
+
+        let f =
+            unsafe { fdb::fdb_transaction_get(trx, key.as_ptr() as *const _, key.len() as i32, 0) };
+        let f = FdbFuture::new(f);
+        TrxGet {
+            trx: self.clone(),
+            inner: f,
+        }
+    }
+
+    pub fn commit(self) -> TrxCommit {
+        let trx = self.inner.inner;
+
+        let f = unsafe { fdb::fdb_transaction_commit(trx) };
+        let f = FdbFuture::new(f);
+        TrxCommit {
+            trx: self,
+            inner: f,
+        }
+    }
+}
+
+struct TransactionInner {
+    inner: *mut fdb::FDBTransaction,
+}
+impl TransactionInner {
+    fn new(inner: *mut fdb::FDBTransaction) -> Self {
+        Self { inner }
+    }
+}
+impl Drop for TransactionInner {
+    fn drop(&mut self) {
+        unsafe {
+            fdb::fdb_transaction_destroy(self.inner);
+        }
+    }
+}
+
+pub struct GetResult {
+    trx: Transaction,
+    inner: FdbFutureResult,
+}
+impl GetResult {
+    pub fn transaction(&self) -> Transaction {
+        self.trx.clone()
+    }
+    pub fn value(&self) -> Result<Option<&[u8]>> {
+        self.inner.get_value()
+    }
+}
+
+pub struct TrxGet {
+    trx: Transaction,
+    inner: FdbFuture,
+}
+impl Future for TrxGet {
+    type Item = GetResult;
+    type Error = FdbError;
+
+    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
+        match self.inner.poll() {
+            Ok(Async::Ready(r)) => Ok(Async::Ready(GetResult {
+                trx: self.trx.clone(),
+                inner: r,
+            })),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub struct TrxCommit {
+    trx: Transaction,
+    inner: FdbFuture,
+}
+impl Future for TrxCommit {
+    //should be ()?
+    type Item = Database;
+    type Error = FdbError;
+
+    fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
+        match self.inner.poll() {
+            Ok(Async::Ready(_r)) => Ok(Async::Ready(self.trx.database.clone())),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(e) => Err(e),
+        }
+    }
+}


### PR DESCRIPTION
Move codes from `examples` to lib.

 - naming: I used `FdbFuture`/`FdbFutureResult` because it sounds similar with `FdbError`. For other things, I used name without `Fdb` prefix, like `Cluster`, `Transaction`, ...
 - namespace: At this time I split each component into a file. Some of them looks too small to be a separated file, like `Cluster`
 - `Result`: I added `error::Result<T> = std::result::Result<T, error::FdbError>` for convenience.