### PR TITLE
add `Transaction::atomic_op`, #15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byteorder"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cc"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +160,7 @@ dependencies = [
 name = "foundationdb"
 version = "0.1.0"
 dependencies = [
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foundationdb-sys 0.1.1",
@@ -503,6 +509,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bindgen 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc7003ec1f7f5579901b5805f401a0defa450b14497c3cba4fbc0496f85ba429"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum cc 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8b9d2900f78631a5876dc5d6c9033ede027253efcd33dd36b1309fc6cab97ee0"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -27,3 +27,4 @@ lazy_static = "1.0"
 
 [dev-dependencies]
 rand = "0.4"
+byteorder = "1.2"

--- a/foundationdb/src/options.rs
+++ b/foundationdb/src/options.rs
@@ -571,77 +571,77 @@ pub enum MutationType {
     /// addend
     ///
     /// Performs an addition of little-endian integers. If the existing value in the database is not present or shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``. The integers to be added must be stored in a little-endian representation.  They can be signed in two's complement representation or unsigned. You can add to an integer at a known offset in the value by prepending the appropriate number of zero bytes to ``param`` and padding with zero bytes to match the length of the value. However, this offset technique requires that you know the addition will not cause the integer field within the value to overflow.
-    Add(Vec<u8>),
+    Add,
     /// value with which to perform bitwise and
     ///
     /// Deprecated
-    And(Vec<u8>),
+    And,
     /// value with which to perform bitwise and
     ///
     /// Performs a bitwise ``and`` operation.  If the existing value in the database is not present, then ``param`` is stored in the database. If the existing value in the database is shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``.
-    BitAnd(Vec<u8>),
+    BitAnd,
     /// value with which to perform bitwise or
     ///
     /// Deprecated
-    Or(Vec<u8>),
+    Or,
     /// value with which to perform bitwise or
     ///
     /// Performs a bitwise ``or`` operation.  If the existing value in the database is not present or shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``.
-    BitOr(Vec<u8>),
+    BitOr,
     /// value with which to perform bitwise xor
     ///
     /// Deprecated
-    Xor(Vec<u8>),
+    Xor,
     /// value with which to perform bitwise xor
     ///
     /// Performs a bitwise ``xor`` operation.  If the existing value in the database is not present or shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``.
-    BitXor(Vec<u8>),
+    BitXor,
     /// value to check against database value
     ///
     /// Performs a little-endian comparison of byte strings. If the existing value in the database is not present or shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``. The larger of the two values is then stored in the database.
-    Max(Vec<u8>),
+    Max,
     /// value to check against database value
     ///
     /// Performs a little-endian comparison of byte strings. If the existing value in the database is not present, then ``param`` is stored in the database. If the existing value in the database is shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``. The smaller of the two values is then stored in the database.
-    Min(Vec<u8>),
+    Min,
     /// value to which to set the transformed key
     ///
     /// Transforms ``key`` using a versionstamp for the transaction. Sets the transformed key in the database to ``param``. A versionstamp is a 10 byte, unique, monotonically (but not sequentially) increasing value for each committed transaction. The first 8 bytes are the committed version of the database. The last 2 bytes are monotonic in the serialization order for transactions. WARNING: At this time versionstamps are compatible with the Tuple layer only in the Java and Python bindings. Note that this implies versionstamped keys may not be used with the Subspace and Directory layers except in those languages.
-    SetVersionstampedKey(Vec<u8>),
+    SetVersionstampedKey,
     /// value to versionstamp and set
     ///
     /// Transforms ``param`` using a versionstamp for the transaction. Sets ``key`` in the database to the transformed parameter. A versionstamp is a 10 byte, unique, monotonically (but not sequentially) increasing value for each committed transaction. The first 8 bytes are the committed version of the database. The last 2 bytes are monotonic in the serialization order for transactions. WARNING: At this time versionstamped values are not compatible with the Tuple layer.
-    SetVersionstampedValue(Vec<u8>),
+    SetVersionstampedValue,
     /// value to check against database value
     ///
     /// Performs lexicographic comparison of byte strings. If the existing value in the database is not present, then ``param`` is stored. Otherwise the smaller of the two values is then stored in the database.
-    ByteMin(Vec<u8>),
+    ByteMin,
     /// value to check against database value
     ///
     /// Performs lexicographic comparison of byte strings. If the existing value in the database is not present, then ``param`` is stored. Otherwise the larger of the two values is then stored in the database.
-    ByteMax(Vec<u8>),
+    ByteMax,
 }
 
 impl MutationType {
     pub fn code(&self) -> fdb::FDBMutationType {
         match *self {
-            MutationType::Add(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_ADD,
-            MutationType::And(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_AND,
-            MutationType::BitAnd(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_BIT_AND,
-            MutationType::Or(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_OR,
-            MutationType::BitOr(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_BIT_OR,
-            MutationType::Xor(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_XOR,
-            MutationType::BitXor(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_BIT_XOR,
-            MutationType::Max(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_MAX,
-            MutationType::Min(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_MIN,
-            MutationType::SetVersionstampedKey(ref _v) => {
+            MutationType::Add => fdb::FDBMutationType_FDB_MUTATION_TYPE_ADD,
+            MutationType::And => fdb::FDBMutationType_FDB_MUTATION_TYPE_AND,
+            MutationType::BitAnd => fdb::FDBMutationType_FDB_MUTATION_TYPE_BIT_AND,
+            MutationType::Or => fdb::FDBMutationType_FDB_MUTATION_TYPE_OR,
+            MutationType::BitOr => fdb::FDBMutationType_FDB_MUTATION_TYPE_BIT_OR,
+            MutationType::Xor => fdb::FDBMutationType_FDB_MUTATION_TYPE_XOR,
+            MutationType::BitXor => fdb::FDBMutationType_FDB_MUTATION_TYPE_BIT_XOR,
+            MutationType::Max => fdb::FDBMutationType_FDB_MUTATION_TYPE_MAX,
+            MutationType::Min => fdb::FDBMutationType_FDB_MUTATION_TYPE_MIN,
+            MutationType::SetVersionstampedKey => {
                 fdb::FDBMutationType_FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_KEY
             }
-            MutationType::SetVersionstampedValue(ref _v) => {
+            MutationType::SetVersionstampedValue => {
                 fdb::FDBMutationType_FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_VALUE
             }
-            MutationType::ByteMin(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_BYTE_MIN,
-            MutationType::ByteMax(ref _v) => fdb::FDBMutationType_FDB_MUTATION_TYPE_BYTE_MAX,
+            MutationType::ByteMin => fdb::FDBMutationType_FDB_MUTATION_TYPE_BYTE_MIN,
+            MutationType::ByteMax => fdb::FDBMutationType_FDB_MUTATION_TYPE_BYTE_MAX,
         }
     }
 }

--- a/foundationdb/tests/atomic.rs
+++ b/foundationdb/tests/atomic.rs
@@ -1,0 +1,118 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/bluejekyll/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate byteorder;
+extern crate foundationdb;
+extern crate foundationdb_sys;
+extern crate futures;
+
+use foundationdb::*;
+
+use byteorder::ByteOrder;
+use futures::future::*;
+
+use error::FdbError;
+
+//TODO: impl Future
+fn atomic_add(db: Database, key: &[u8], value: i64) -> Box<Future<Item = (), Error = FdbError>> {
+    let trx = match db.create_trx() {
+        Ok(trx) => trx,
+        Err(e) => return Box::new(err(e)),
+    };
+
+    let val = {
+        let mut buf = [0u8; 8];
+        byteorder::LE::write_i64(&mut buf, value);
+        buf
+    };
+    trx.atomic_op(key, &val, options::MutationType::Add);
+
+    let fut = trx.commit().map(|_trx| ());
+    Box::new(fut)
+}
+
+//TODO: impl Future
+fn example_atomic() -> Box<Future<Item = (), Error = FdbError>> {
+    const KEY: &[u8] = b"test-atomic";
+
+    let fut = Cluster::new(foundationdb::default_config_path())
+        .and_then(|cluster| cluster.create_database())
+        .and_then(|db| {
+            // clear key before run example
+            result(db.create_trx())
+                .and_then(|trx| {
+                    trx.clear(KEY);
+                    trx.commit()
+                })
+                .map(|trx| trx.database())
+        })
+        .and_then(|db| {
+            let n = 1000usize;
+
+            // Run `n` add(1) operations in parallel
+            let db0 = db.clone();
+            let fut_add_list = (0..n)
+                .into_iter()
+                .map(move |_| atomic_add(db0.clone(), KEY, 1))
+                .collect::<Vec<_>>();
+            let fut_add = join_all(fut_add_list);
+
+            // Run `n` add(-1) operations in parallel
+            let db0 = db.clone();
+            let fut_sub_list = (0..n)
+                .into_iter()
+                .map(move |_| atomic_add(db0.clone(), KEY, -1))
+                .collect::<Vec<_>>();
+            let fut_sub = join_all(fut_sub_list);
+
+            // Wait for all atomic operations
+            fut_add.join(fut_sub).map(move |_| db)
+        })
+        .and_then(|db| result(db.create_trx()).and_then(|trx| trx.get(KEY)))
+        .and_then(|res| {
+            let value = res.value()
+                .expect("failed to get value")
+                .expect("value should exists");
+
+            // A value should be zero, as same number of atomic add/sub operations are done.
+            let v: i64 = byteorder::LE::read_i64(&value);
+            if v != 0 {
+                panic!("expected 0, found {}", v);
+            }
+
+            Ok(())
+        });
+
+    Box::new(fut)
+}
+
+#[test]
+fn atomic() {
+    use fdb_api::FdbApiBuilder;
+
+    let network = FdbApiBuilder::default()
+        .build()
+        .expect("failed to init api")
+        .network()
+        .build()
+        .expect("failed to init network");
+
+    let handle = std::thread::spawn(move || {
+        let error = network.run();
+
+        if let Err(error) = error {
+            panic!("fdb_run_network: {}", error);
+        }
+    });
+
+    network.wait();
+
+    example_atomic().wait().expect("failed to run");
+
+    network.stop().expect("failed to stop network");
+    handle.join().expect("failed to join fdb thread");
+}


### PR DESCRIPTION
I update `options.rs` to remove `Vec<u8>` from `MutationType` enum. It breaks API but I'm not sure if we should bump version number, as those options are not used in API before.

It seems that Golang API splits all operations into seperated functions [1], so it has `BitAnd`, `BitOr` API functions. I think taking enum as a parameter is better than having functions for each enums.

I think current function signature is okay for all `MutationType` except `Add`. For `Add`, Foundationdb requires little-endian two's complement encoding, so caller should encode value with `byteorder` or `std::mem::transmute`. We might better to add helper API like `atomic_add_i64(&self, key: &[u8], value: i64)` for those cases.

[1] https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb#Transaction