### PR TITLE
add `Transaction::get_range`, #14

### DIFF
--- a/foundationdb-gen/src/bin/foundationdb-options-gen.rs
+++ b/foundationdb-gen/src/bin/foundationdb-options-gen.rs
@@ -18,6 +18,13 @@ struct FdbScope {
 impl FdbScope {
     fn gen_ty(&self) -> String {
         let mut s = String::new();
+        let with_ty = self.with_ty();
+
+        if with_ty {
+            s += "#[derive(Clone,Debug)]\n";
+        } else {
+            s += "#[derive(Clone,Copy,Debug)]\n";
+        }
         s += "pub enum ";
         s += &self.name;
         s += "{\n";

--- a/foundationdb/examples/hello.rs
+++ b/foundationdb/examples/hello.rs
@@ -25,7 +25,7 @@ fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
             trx.commit()
         })
         .and_then(|trx| result(trx.database().create_trx()))
-        .and_then(|trx| trx.get(b"hello"))
+        .and_then(|trx| trx.get(b"hello", false))
         .and_then(|res| {
             let val = res.value();
             eprintln!("value: {:?}", val);
@@ -35,7 +35,7 @@ fn example_set_get() -> Box<Future<Item = (), Error = FdbError>> {
             trx.commit()
         })
         .and_then(|trx| result(trx.database().create_trx()))
-        .and_then(|trx| trx.get(b"hello"))
+        .and_then(|trx| trx.get(b"hello", false))
         .and_then(|res| {
             eprintln!("value: {:?}", res.value());
             Ok(())
@@ -51,7 +51,7 @@ fn example_get_multi() -> Box<Future<Item = (), Error = FdbError>> {
         .and_then(|trx| {
             let keys: &[&[u8]] = &[b"hello", b"world", b"foo", b"bar"];
 
-            let futs = keys.iter().map(|k| trx.get(k)).collect::<Vec<_>>();
+            let futs = keys.iter().map(|k| trx.get(k, false)).collect::<Vec<_>>();
             join_all(futs)
         })
         .and_then(|results| {

--- a/foundationdb/examples/range.rs
+++ b/foundationdb/examples/range.rs
@@ -1,0 +1,90 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/bluejekyll/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate foundationdb;
+extern crate foundationdb_sys;
+extern crate futures;
+extern crate rand;
+
+use foundationdb::keyselector::*;
+use foundationdb::*;
+
+use futures::future::*;
+use futures::stream::*;
+
+use error::FdbError;
+
+fn random_str(len: usize) -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    rng.gen_ascii_chars().take(len).collect::<String>()
+}
+
+fn example_get_range() -> Box<Future<Item = (), Error = FdbError>> {
+    const N: usize = 10000;
+
+    let fut = Cluster::new(foundationdb::default_config_path())
+        .and_then(|cluster| cluster.create_database())
+        .and_then(|db| result(db.create_trx()))
+        .and_then(|trx| {
+            let key_begin = "test-range-";
+            let key_end = "test-range.";
+
+            trx.clear_range(key_begin.as_bytes(), key_end.as_bytes());
+
+            for _ in 0..N {
+                let key = format!("{}-{}", key_begin, random_str(10));
+                let value = random_str(10);
+                trx.set(key.as_bytes(), value.as_bytes());
+            }
+
+            let begin = KeySelector::first_greater_or_equal(key_begin.as_bytes());
+            let end = KeySelector::first_greater_than(key_end.as_bytes());
+            let opt = transaction::RangeOptionBuilder::new(begin, end).build();
+
+            let stream = trx.get_range(opt);
+            stream
+                .fold(0, |count, item| {
+                    let kvs = item.keyvalues()?;
+                    Ok(count + kvs.as_ref().len())
+                })
+                .map(|count| {
+                    if count != N {
+                        panic!("count expected={}, found={}", N, count);
+                    }
+                    eprintln!("count: {:?}", count);
+                })
+        });
+
+    Box::new(fut)
+}
+
+fn main() {
+    use fdb_api::FdbApiBuilder;
+
+    let network = FdbApiBuilder::default()
+        .build()
+        .expect("failed to init api")
+        .network()
+        .build()
+        .expect("failed to init network");
+
+    let handle = std::thread::spawn(move || {
+        let error = network.run();
+
+        if let Err(error) = error {
+            panic!("fdb_run_network: {}", error);
+        }
+    });
+
+    network.wait();
+
+    example_get_range().wait().expect("failed to run");
+
+    network.stop().expect("failed to stop network");
+    handle.join().expect("failed to join fdb thread");
+}

--- a/foundationdb/examples/range.rs
+++ b/foundationdb/examples/range.rs
@@ -46,10 +46,10 @@ fn example_get_range() -> Box<Future<Item = (), Error = FdbError>> {
             let end = KeySelector::first_greater_than(key_end.as_bytes());
             let opt = transaction::RangeOptionBuilder::new(begin, end).build();
 
-            let stream = trx.get_range(opt);
-            stream
+            trx.get_ranges(opt)
+                .map_err(|(_opt, e)| e)
                 .fold(0, |count, item| {
-                    let kvs = item.keyvalues()?;
+                    let kvs = item.keyvalues();
                     Ok(count + kvs.as_ref().len())
                 })
                 .map(|count| {

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -204,7 +204,6 @@ impl FdbFutureResult {
         Ok(Some(slice))
     }
 
-    #[allow(unused)]
     pub(crate) fn get_string_array(&self) -> Result<Vec<&[u8]>> {
         use std::os::raw::c_char;
 
@@ -231,7 +230,6 @@ impl FdbFutureResult {
         Ok(v)
     }
 
-    #[allow(unused)]
     pub(crate) fn get_keyvalue_array<'a>(&'a self) -> Result<KeyValues<'a>> {
         let mut out_keyvalues = std::ptr::null();
         let mut out_len = 0;

--- a/foundationdb/src/keyselector.rs
+++ b/foundationdb/src/keyselector.rs
@@ -1,0 +1,91 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/bluejekyll/foundationdb-rs/graphs/contributors
+// Copyright 2013-2018 Apple, Inc and the FoundationDB project authors.
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+///TODO: revise
+//TODO: introduces a Trait to cover both KeySelector/OwnedKeySelector?
+#[derive(Clone, Debug)]
+pub struct KeySelector<'a> {
+    key: &'a [u8],
+    or_equal: bool,
+    offset: usize,
+}
+
+impl<'a> KeySelector<'a> {
+    pub fn new(key: &'a [u8], or_equal: bool, offset: usize) -> Self {
+        Self {
+            key,
+            or_equal,
+            offset,
+        }
+    }
+
+    pub fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    pub fn or_equal(&self) -> bool {
+        self.or_equal
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn to_owned(&self) -> OwnedKeySelector {
+        OwnedKeySelector::new(self.key.to_vec(), self.or_equal, self.offset)
+    }
+
+    pub fn last_less_than(key: &'a [u8]) -> Self {
+        Self::new(key, false, 0)
+    }
+    pub fn last_less_or_equal(key: &'a [u8]) -> Self {
+        Self::new(key, true, 0)
+    }
+
+    pub fn first_greater_than(key: &'a [u8]) -> Self {
+        Self::new(key, true, 1)
+    }
+    pub fn first_greater_or_equal(key: &'a [u8]) -> Self {
+        Self::new(key, false, 1)
+    }
+}
+
+///TODO: revise
+pub struct OwnedKeySelector {
+    //TODO: Box<[u8]>?
+    key: Vec<u8>,
+    or_equal: bool,
+    offset: usize,
+}
+
+impl OwnedKeySelector {
+    pub fn new(key: Vec<u8>, or_equal: bool, offset: usize) -> Self {
+        Self {
+            key,
+            or_equal,
+            offset,
+        }
+    }
+
+    pub fn key(&self) -> &[u8] {
+        self.key.as_ref()
+    }
+
+    pub fn or_equal(&self) -> bool {
+        self.or_equal
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    //TODO: better naming
+    pub(crate) fn as_selector(&self) -> KeySelector {
+        KeySelector::new(self.key.as_slice(), self.or_equal, self.offset)
+    }
+}

--- a/foundationdb/src/keyselector.rs
+++ b/foundationdb/src/keyselector.rs
@@ -6,64 +6,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-///TODO: revise
-//TODO: introduces a Trait to cover both KeySelector/OwnedKeySelector?
 #[derive(Clone, Debug)]
-pub struct KeySelector<'a> {
-    key: &'a [u8],
-    or_equal: bool,
-    offset: usize,
-}
-
-impl<'a> KeySelector<'a> {
-    pub fn new(key: &'a [u8], or_equal: bool, offset: usize) -> Self {
-        Self {
-            key,
-            or_equal,
-            offset,
-        }
-    }
-
-    pub fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    pub fn or_equal(&self) -> bool {
-        self.or_equal
-    }
-
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-
-    pub fn to_owned(&self) -> OwnedKeySelector {
-        OwnedKeySelector::new(self.key.to_vec(), self.or_equal, self.offset)
-    }
-
-    pub fn last_less_than(key: &'a [u8]) -> Self {
-        Self::new(key, false, 0)
-    }
-    pub fn last_less_or_equal(key: &'a [u8]) -> Self {
-        Self::new(key, true, 0)
-    }
-
-    pub fn first_greater_than(key: &'a [u8]) -> Self {
-        Self::new(key, true, 1)
-    }
-    pub fn first_greater_or_equal(key: &'a [u8]) -> Self {
-        Self::new(key, false, 1)
-    }
-}
-
-///TODO: revise
-pub struct OwnedKeySelector {
+pub struct KeySelector {
     //TODO: Box<[u8]>?
+    //TODO: introduces BorrowedKeySelector?
     key: Vec<u8>,
     or_equal: bool,
     offset: usize,
 }
 
-impl OwnedKeySelector {
+impl KeySelector {
     pub fn new(key: Vec<u8>, or_equal: bool, offset: usize) -> Self {
         Self {
             key,
@@ -84,8 +36,17 @@ impl OwnedKeySelector {
         self.offset
     }
 
-    //TODO: better naming
-    pub(crate) fn as_selector(&self) -> KeySelector {
-        KeySelector::new(self.key.as_slice(), self.or_equal, self.offset)
+    pub fn last_less_than(key: &[u8]) -> Self {
+        Self::new(key.to_vec(), false, 0)
+    }
+    pub fn last_less_or_equal(key: &[u8]) -> Self {
+        Self::new(key.to_vec(), true, 0)
+    }
+
+    pub fn first_greater_than(key: &[u8]) -> Self {
+        Self::new(key.to_vec(), true, 1)
+    }
+    pub fn first_greater_or_equal(key: &[u8]) -> Self {
+        Self::new(key.to_vec(), false, 1)
     }
 }

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -88,7 +88,7 @@
 //!
 //! // read a value
 //! let trx = db.create_trx().expect("failed to create transaction");
-//! let result = trx.get(b"hello").wait().expect("failed to read world from hello");
+//! let result = trx.get(b"hello", false).wait().expect("failed to read world from hello");
 //!
 //! let value: &[u8] = result.value()
 //!     .expect("failed to get value from result") // unwrap the error
@@ -122,6 +122,8 @@ pub mod database;
 pub mod error;
 pub mod fdb_api;
 pub mod future;
+#[allow(missing_docs)]
+pub mod keyselector;
 pub mod network;
 /// Generated configuration types for use with the various `set_option` functions
 #[allow(missing_docs)]

--- a/foundationdb/src/options.rs
+++ b/foundationdb/src/options.rs
@@ -2,6 +2,7 @@ use error;
 use foundationdb_sys as fdb;
 use std;
 
+#[derive(Clone, Debug)]
 pub enum NetworkOption {
     /// IP:PORT
     ///
@@ -230,6 +231,7 @@ impl NetworkOption {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum DatabaseOption {
     /// Max location cache entries
     ///
@@ -291,6 +293,7 @@ impl DatabaseOption {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum TransactionOption {
     /// The transaction, if not self-conflicting, may be committed a second time after commit succeeds, in the event of a fault
     CausalWriteRisky,
@@ -536,6 +539,7 @@ impl TransactionOption {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum StreamingMode {
     /// Client intends to consume the entire range and would like it all transferred as early as possible.
     WantAll,
@@ -567,6 +571,7 @@ impl StreamingMode {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum MutationType {
     /// addend
     ///
@@ -646,6 +651,7 @@ impl MutationType {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum ConflictRangeType {
     /// Used to add a read conflict range
     Read,
@@ -662,6 +668,7 @@ impl ConflictRangeType {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum ErrorPredicate {
     /// Returns ``true`` if the error indicates the operations in the transactions should be retried because of transient error.
     Retryable,

--- a/foundationdb/tests/atomic.rs
+++ b/foundationdb/tests/atomic.rs
@@ -72,7 +72,7 @@ fn example_atomic() -> Box<Future<Item = (), Error = FdbError>> {
             // Wait for all atomic operations
             fut_add.join(fut_sub).map(move |_| db)
         })
-        .and_then(|db| result(db.create_trx()).and_then(|trx| trx.get(KEY)))
+        .and_then(|db| result(db.create_trx()).and_then(|trx| trx.get(KEY, false)))
         .and_then(|res| {
             let value = res.value()
                 .expect("failed to get value")


### PR DESCRIPTION
I encountered tons of design issues which I don't have an answer. I need some help :). I tried to write `TODO` comment for each problems. Here's some other issues which is not written in `TODO`.

 - `KeyValuesStream`: It returns a chunk of `KeyValue<'a>` at a time, instead of emitting a key-value at a time. I thought that it's better to expose lowest-level API without introducing some overhead, but it might introduce some usability issue.
 - About `Transaction::get_range`
   - I implemented it to return a stream, but it gives a illusion to users that they might be able to scan very large range of key-values in single transaction, while foundationdb only allows single transaction with maximum 5 seconds (and they recommends much shorter transaction duration for performance).
   - In current design, there's no easy way to re-start new transaction to continue scan. We might change API as following to allow user to split single scan over multiple transactions, so that can use `Future::loop_fn` to scan range of keys.
```rust
impl Transaction { fn get_range(&self, opt: RangeOption) -> TrxRange; }
impl Future for TrxRange { type Item = RangeResult; type Error = FdbError; }
impl RangeResult {
  fn keyvalues(&self) -> Result<KeyValues<'a>>;
  fn next(&self) -> Option<RangeOption>; // caller can pass a return value for next `get_range` call
}
```
 - `KeySelector<'a>`/`OwnedKeySelector`: I'm not sure how to clean up `keyselector`. Maybe we can just remove `KeySelector<'a>`, but I'm feeling guilty for copying values... :(