### PR TITLE
move examples into tests, clean-up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,5 @@ script:
   - cargo test --manifest-path foundationdb-sys/Cargo.toml --all-features
   - cargo test --manifest-path foundationdb-gen/Cargo.toml --all-features
   - cargo test --manifest-path foundationdb/Cargo.toml --all-features
-  - cargo run --manifest-path foundationdb/Cargo.toml --all-features --example hello
 
 # after_success: cargo kcov here...

--- a/foundationdb/examples/README.md
+++ b/foundationdb/examples/README.md
@@ -1,0 +1,1 @@
+See [tests](../tests/) for examples

--- a/foundationdb/tests/common/mod.rs
+++ b/foundationdb/tests/common/mod.rs
@@ -1,0 +1,65 @@
+extern crate rand;
+extern crate std;
+
+use foundationdb::*;
+
+/// generate random string. Foundationdb watch only fires when value changed, so updating with same
+/// value twice will not fire watches. To make examples work over multiple run, we use random
+/// string as a value.
+#[allow(unused)]
+pub fn random_str(len: usize) -> String {
+    use self::rand::Rng;
+    let mut rng = rand::thread_rng();
+    rng.gen_ascii_chars().take(len).collect::<String>()
+}
+
+#[allow(unused)]
+pub fn setup_static() {
+    let _env = &*ENV;
+}
+
+lazy_static! {
+    static ref ENV: TestEnv = { TestEnv::new() };
+}
+
+pub struct TestEnv {
+    network: network::Network,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl TestEnv {
+    pub fn new() -> Self {
+        let network = fdb_api::FdbApiBuilder::default()
+            .build()
+            .expect("failed to init api")
+            .network()
+            .build()
+            .expect("failed to init network");
+
+        let handle = std::thread::spawn(move || {
+            let error = network.run();
+
+            if let Err(error) = error {
+                panic!("fdb_run_network: {}", error);
+            }
+        });
+
+        network.wait();
+
+        Self {
+            network,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        self.network.stop().expect("failed to stop network");
+        self.handle
+            .take()
+            .expect("cannot dropped twice")
+            .join()
+            .expect("failed to join fdb thread");
+    }
+}

--- a/foundationdb/tests/network.rs
+++ b/foundationdb/tests/network.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/bluejekyll/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate foundationdb;
+#[macro_use]
+extern crate lazy_static;
+
+mod common;
+
+#[test]
+fn setup_network() {
+    let _env = common::TestEnv::new();
+}

--- a/foundationdb/tests/range.rs
+++ b/foundationdb/tests/range.rs
@@ -6,25 +6,21 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate foundationdb;
-extern crate foundationdb_sys;
 extern crate futures;
-extern crate rand;
+#[macro_use]
+extern crate lazy_static;
 
-use foundationdb::keyselector::*;
 use foundationdb::*;
-
 use futures::future::*;
-use futures::stream::*;
+use futures::prelude::*;
 
-use error::FdbError;
+mod common;
 
-fn random_str(len: usize) -> String {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    rng.gen_ascii_chars().take(len).collect::<String>()
-}
+#[test]
+fn test_get_range() {
+    use foundationdb::keyselector::KeySelector;
 
-fn example_get_range() -> Box<Future<Item = (), Error = FdbError>> {
+    common::setup_static();
     const N: usize = 10000;
 
     let fut = Cluster::new(foundationdb::default_config_path())
@@ -37,8 +33,8 @@ fn example_get_range() -> Box<Future<Item = (), Error = FdbError>> {
             trx.clear_range(key_begin.as_bytes(), key_end.as_bytes());
 
             for _ in 0..N {
-                let key = format!("{}-{}", key_begin, random_str(10));
-                let value = random_str(10);
+                let key = format!("{}-{}", key_begin, common::random_str(10));
+                let value = common::random_str(10);
                 trx.set(key.as_bytes(), value.as_bytes());
             }
 
@@ -60,31 +56,5 @@ fn example_get_range() -> Box<Future<Item = (), Error = FdbError>> {
                 })
         });
 
-    Box::new(fut)
-}
-
-fn main() {
-    use fdb_api::FdbApiBuilder;
-
-    let network = FdbApiBuilder::default()
-        .build()
-        .expect("failed to init api")
-        .network()
-        .build()
-        .expect("failed to init network");
-
-    let handle = std::thread::spawn(move || {
-        let error = network.run();
-
-        if let Err(error) = error {
-            panic!("fdb_run_network: {}", error);
-        }
-    });
-
-    network.wait();
-
-    example_get_range().wait().expect("failed to run");
-
-    network.stop().expect("failed to stop network");
-    handle.join().expect("failed to join fdb thread");
+    fut.wait().expect("failed to run")
 }


### PR DESCRIPTION
I moved all examples/tests to `test.rs`, to organize some (integration?) tests.

There are some alternatives to manage tests
 1. Keep all tests in single file, and use custom runner for each test: It works, but we cannot get usual `cargo test` style output or do test filtering for the test.
 2. Keep all tests in single file, and use `#[test]` for each test: Rust does not support setup/teardown for `#[test]`. To run multiple `#[test]` function in single binary, we should have global fdb network for those tests, and it seems that there's no easy way to clean-up the global network.
 3. Keep each tests on a seperated file, and add helper function for setup/teardown: I dislike this approach because an output of `cargo test` becomes noisy as tests grows.

I choose second option and add additional test for testing network setup/teardown only.