### PR TITLE
add bindingtester to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ matrix:
       script:
         - cargo fmt --all -- --write-mode=diff
 
+    ## bindingtester
+    - rust: stable
+      env: RUST_BACKTRACE=full
+      script:
+        - scripts/run_bindingtester.sh
+
   allow_failures:
     - rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,32 +7,39 @@ matrix:
     # optional feature variations
     # we want full coverage, include all features...
     - rust: stable
-      env: RUST_BACKTRACE=full
+      env: NAME=stable
+           RUST_BACKTRACE=full
 
     - rust: beta
-      env: RUST_BACKTRACE=full
+      env: NAME=beta
+           RUST_BACKTRACE=full
 
     - os: osx
       rust: stable
+      env: NAME=macos
+           RUST_BACKTRACE=full
 
     - rust: nightly
       env: RUST_BACKTRACE=full
 
     - rust: nightly
-      env: RUST_BACKTRACE=full
+      env: NAME=clippy
+           RUST_BACKTRACE=full
            CLIPPY=true
       script:
         - cargo clippy --all --all-features
 
     - rust: nightly
-      env: RUST_BACKTRACE=full
+      env: NAME=rustfmt
+           RUST_BACKTRACE=full
            RUSTFMT=true
       script:
         - cargo fmt --all -- --write-mode=diff
 
     ## bindingtester
     - rust: stable
-      env: RUST_BACKTRACE=full
+      env: NAME=bindingtester
+           RUST_BACKTRACE=full
       script:
         - scripts/run_bindingtester.sh
 

--- a/scripts/install_foundationdb_linux.sh
+++ b/scripts/install_foundationdb_linux.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -x
+
 curl -O https://www.foundationdb.org/downloads/5.1.5/ubuntu/installers/foundationdb-clients_5.1.5-1_amd64.deb
 curl -O https://www.foundationdb.org/downloads/5.1.5/ubuntu/installers/foundationdb-server_5.1.5-1_amd64.deb
 

--- a/scripts/install_foundationdb_macos.sh
+++ b/scripts/install_foundationdb_macos.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -x
+
 curl -O https://www.foundationdb.org/downloads/5.1.5/macOS/installers/FoundationDB-5.1.5.pkg
 
 sudo installer -pkg FoundationDB-5.1.5.pkg -target /

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -22,10 +22,12 @@ esac
 
 ## build the python bindings
 (
-  cd /tmp
+  fdb_builddir=${fdb_rs_dir:?}/target/foundationdb_build
+  mkdir -p ${fdb_builddir:?}
+  cd ${fdb_builddir:?}
 
   ## Get foundationdb source
-  git clone git@github.com:apple/foundationdb.git
+  git clone https://github.com/apple/foundationdb.git
   cd foundationdb
 
   ## currently we only support 5.1

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -27,7 +27,7 @@ esac
   cd ${fdb_builddir:?}
 
   ## Get foundationdb source
-  git clone https://github.com/apple/foundationdb.git
+  git clone --depth 1 https://github.com/apple/foundationdb.git
   cd foundationdb
 
   ## currently we only support 5.1

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -27,7 +27,7 @@ esac
   cd ${fdb_builddir:?}
 
   ## Get foundationdb source
-  git clone --depth 1 https://github.com/apple/foundationdb.git
+  git clone --depth 1 https://github.com/apple/foundationdb.git -b release-5.1
   cd foundationdb
 
   ## currently we only support 5.1

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-fdb_rs_dir=$(dirname $0)/..
+fdb_rs_dir=$(pwd)
 
 case $(uname) in
   Darwin) 

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -e
+
+set -x
+
+fdb_rs_dir=$(dirname $0)/..
+
+case $(uname) in
+  Darwin) 
+    brew install mono
+  ;;
+  Linux)
+    sudo apt install mono-devel
+  ;;
+  *) echo "only macOS or Ubuntu is supported"
+esac
+
+## build the rust bindingtester
+(
+  cd ${fdb_rs_dir:?}
+  cargo build --manifest-path foundationdb/Cargo.toml  --bin bindingtester 
+)
+
+## build the python bindings
+(
+  cd /tmp
+
+  ## Get foundationdb source
+  git clone git@github.com:apple/foundationdb.git
+  cd foundationdb
+
+  ## currently we only support 5.1
+  git checkout release-5.1
+
+  ## need the python api bindings
+  make fdb_python
+  
+  ## Run the test
+  ./bindings/bindingtester/bindingtester.py --no-threads --seed 100 ${fdb_rs_dir:?}/target/debug/bindingtester
+)


### PR DESCRIPTION
This adds the `scripts/run_bindingtester.sh` which:

1. installs the `mono` dependency needed for the python build
2. builds the `bindingtester` bin
3. syncs the foundationdb repo
4. builds the python bindings
5. runs the `bindingtester.py` script