### PR TITLE
fix segfault on watch test, #58

### DIFF
--- a/foundationdb/src/cluster.rs
+++ b/foundationdb/src/cluster.rs
@@ -34,10 +34,11 @@ impl Cluster {
     /// TODO: implement Default for Cluster where: If cluster_file_path is NULL or an empty string, then a default cluster file will be used. see
     pub fn new(path: &str) -> ClusterGet {
         let path_str = std::ffi::CString::new(path).unwrap();
-        let f = unsafe { fdb::fdb_create_cluster(path_str.as_ptr()) };
-        ClusterGet {
-            inner: FdbFuture::new(f),
-        }
+        let inner = unsafe {
+            let f = fdb::fdb_create_cluster(path_str.as_ptr());
+            FdbFuture::new(f)
+        };
+        ClusterGet { inner }
     }
 
     // TODO: fdb_cluster_set_option impl

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -26,8 +26,10 @@ use transaction::*;
 /// Modifications to a database are performed via transactions.
 #[derive(Clone)]
 pub struct Database {
-    cluster: Cluster,
+    // Order of fields should not be changed, because Rust drops field top-to-bottom (rfc1857), and
+    // database should be dropped before cluster.
     inner: Arc<DatabaseInner>,
+    cluster: Cluster,
 }
 impl Database {
     pub(crate) fn new(cluster: Cluster, db: *mut fdb::FDBDatabase) -> Self {

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -29,7 +29,8 @@ pub(crate) struct FdbFuture {
 }
 
 impl FdbFuture {
-    pub(crate) fn new(f: *mut fdb::FDBFuture) -> Self {
+    // `new` is marked as unsafe because it's lifetime is not well-defined.
+    pub(crate) unsafe fn new(f: *mut fdb::FDBFuture) -> Self {
         Self {
             f: Some(f),
             task: None,


### PR DESCRIPTION
The segfault (#58) happens when watch outlives database/cluster. It happens befause `TrxWatch` does not keep any refcount to database/cluster. I fixed the issue by making all `FdbFuture` live with either `Transaction` or `Database`.

I found another possible problem while fixing the issue, which is caused by drop order of Rust. Rust drops struct field from top to bottom[1]. If we define `Cluster` prior to `Database`, cluster will be dropped before `Database`, which might cause a problem. `valgrind` does not complain for this case but I changed the field order to just make sure.

[1] https://github.com/rust-lang/rfcs/blob/master/text/1857-stabilize-drop-order.md#tuples-structs-and-enum-variants