### PR TITLE
refactor the `tuple` module

### DIFF
--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -179,7 +179,7 @@ impl Instr {
 
         let tup: tuple::Value = Tuple::decode(data).unwrap();
         let cmd = match tup.0[0] {
-            SingleValue::Str(ref s) => s.clone(),
+            single::Value::Str(ref s) => s.clone(),
             _ => panic!("unexpected instr"),
         };
 
@@ -723,7 +723,7 @@ impl StackMachine {
                 let mut data = data.as_slice();
 
                 while !data.is_empty() {
-                    let (val, offset): (SingleValue, _) = Single::decode(data).unwrap();
+                    let (val, offset): (single::Value, _) = Single::decode(data).unwrap();
                     let bytes = Single::encode_to_vec(&val);
                     self.push_single(number, &bytes);
                     data = &data[offset..];

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -177,7 +177,7 @@ impl Instr {
     fn from(data: &[u8]) -> Self {
         use InstrCode::*;
 
-        let tup: TupleValue = Tuple::decode(data).unwrap();
+        let tup: tuple::Value = Tuple::decode(data).unwrap();
         let cmd = match tup.0[0] {
             SingleValue::Str(ref s) => s.clone(),
             _ => panic!("unexpected instr"),

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use fdb::error::FdbError;
 use fdb::keyselector::KeySelector;
 use fdb::tuple::*;
+use fdb::tuple::single::*;
 use fdb::*;
 use futures::future::*;
 use futures::prelude::*;

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -15,7 +15,7 @@
 //! general guidance on subspace usage, see the Subspaces section of the Developer Guide
 //! (https://apple.github.io/foundationdb/developer-guide.html#subspaces).
 
-use tuple::{Tuple, TupleError};
+use tuple::{self, Tuple};
 
 /// Subspace represents a well-defined region of keyspace in a FoundationDB database.
 #[derive(Debug, Clone)]

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -15,7 +15,7 @@
 //! general guidance on subspace usage, see the Subspaces section of the Developer Guide
 //! (https://apple.github.io/foundationdb/developer-guide.html#subspaces).
 
-use tuple::{self, Tuple};
+use tuple::{self, Encode, Decode};
 
 /// Subspace represents a well-defined region of keyspace in a FoundationDB database.
 #[derive(Debug, Clone)]
@@ -36,14 +36,14 @@ impl Subspace {
         }
     }
 
-    /// `from_bytes` returns a new Subspace from the provided Tuple.
-    pub fn new<T: Tuple>(t: &T) -> Self {
-        let prefix = Tuple::encode_to_vec(t);
+    /// Returns a new Subspace from the provided tuple encodable.
+    pub fn new<T: Encode>(t: &T) -> Self {
+        let prefix = Encode::encode_to_vec(t);
         Self { prefix }
     }
 
-    /// `subspace` returns a new Subspace whose prefix extends this Subspace with a given tuple.
-    pub fn subspace<T: Tuple>(&self, t: &T) -> Self {
+    /// Returns a new Subspace whose prefix extends this Subspace with a given tuple encodable.
+    pub fn subspace<T: Encode>(&self, t: &T) -> Self {
         Self {
             prefix: self.pack(t),
         }
@@ -54,10 +54,10 @@ impl Subspace {
         self.prefix.as_slice()
     }
 
-    /// `pack` returns the key encoding the specified Tuple with the prefix of this Subspace
+    /// Returns the key encoding the specified Tuple with the prefix of this Subspace
     /// prepended.
-    pub fn pack<T: Tuple>(&self, t: &T) -> Vec<u8> {
-        let mut packed = Tuple::encode_to_vec(t);
+    pub fn pack<T: Encode>(&self, t: &T) -> Vec<u8> {
+        let mut packed = Encode::encode_to_vec(t);
         let mut out = Vec::with_capacity(self.prefix.len() + packed.len());
         out.extend_from_slice(&self.prefix);
         out.append(&mut packed);
@@ -67,12 +67,12 @@ impl Subspace {
     /// `unpack` returns the Tuple encoded by the given key with the prefix of this Subspace
     /// removed.  `unpack` will return an error if the key is not in this Subspace or does not
     /// encode a well-formed Tuple.
-    pub fn unpack<T: Tuple>(&self, key: &[u8]) -> Result<T, TupleError> {
+    pub fn unpack<T: Decode>(&self, key: &[u8]) -> Result<T, tuple::Error> {
         if !self.is_start_of(key) {
-            return Err(TupleError::InvalidData);
+            return Err(tuple::Error::InvalidData);
         }
         let key = &key[self.prefix.len()..];
-        Tuple::decode(&key)
+        Decode::decode(&key)
     }
 
     /// `is_start_of` returns true if the provided key starts with the prefix of this Subspace,
@@ -114,7 +114,7 @@ mod tests {
         let tup = (2, 3);
 
         let packed = ss0.pack(&tup);
-        let expected = Tuple::encode_to_vec(&(1, 2, 3));
+        let expected = Encode::encode_to_vec(&(1, 2, 3));
         assert_eq!(expected, packed);
 
         let tup_unpack: (i64, i64) = ss0.unpack(&packed).unwrap();

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -143,7 +143,7 @@ mod tests {
             v
         };
 
-        assert!(ss0.unpack::<tuple::TupleValue>(&malformed).is_err());
+        assert!(ss0.unpack::<tuple::Value>(&malformed).is_err());
     }
 
     #[test]

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -100,9 +100,9 @@ impl RangeOptionBuilder {
     /// Create new builder with a tuple as a prefix
     pub fn from_tuple<T>(tup: &T) -> Self
     where
-        T: tuple::Tuple,
+        T: tuple::Encode,
     {
-        let bytes = tuple::Tuple::encode_to_vec(tup);
+        let bytes = tuple::Encode::encode_to_vec(tup);
         let mut begin = bytes.clone();
         begin.push(0x00);
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -1,0 +1,120 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/bluejekyll/foundationdb-rs/graphs/contributors
+// Copyright 2013-2018 Apple, Inc and the FoundationDB project authors.
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Tuple Key type like that of other FoundationDB libraries
+
+pub mod single;
+
+use std::{self, io::Write, string::FromUtf8Error};
+use self::single::{Single, SingleValue};
+
+#[derive(Debug, Fail)]
+pub enum TupleError {
+    #[fail(display = "Unexpected end of file")]
+    EOF,
+    #[fail(display = "Invalid type: {}", value)]
+    InvalidType { value: u8 },
+    #[fail(display = "Invalid data")]
+    InvalidData,
+    #[fail(display = "UTF8 conversion error")]
+    FromUtf8Error(FromUtf8Error),
+}
+
+type Result<T> = std::result::Result<T, TupleError>;
+
+impl From<FromUtf8Error> for TupleError {
+    fn from(error: FromUtf8Error) -> Self {
+        TupleError::FromUtf8Error(error)
+    }
+}
+
+pub trait Tuple: Sized {
+    fn encode<W: Write>(&self, _w: &mut W) -> std::io::Result<()>;
+    fn encode_to_vec(&self) -> Vec<u8> {
+        let mut v = Vec::new();
+        self.encode(&mut v)
+            .expect("tuple encoding should never fail");
+        v
+    }
+
+    fn decode(buf: &[u8]) -> Result<Self>;
+}
+
+macro_rules! tuple_impls {
+    ($($len:expr => ($($n:tt $name:ident)+))+) => {
+        $(
+            impl<$($name),+> Tuple for ($($name,)+)
+            where
+                $($name: Single + Default,)+
+            {
+                #[allow(non_snake_case, unused_assignments, deprecated)]
+                fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+                    $(
+                        self.$n.encode(w)?;
+                    )*
+                    Ok(())
+                }
+
+                #[allow(non_snake_case, unused_assignments, deprecated)]
+                fn decode(buf: &[u8]) -> Result<Self> {
+                    let mut buf = buf;
+                    let mut out: Self = Default::default();
+                    $(
+                        let (v0, offset0) = $name::decode(buf)?;
+                        out.$n = v0;
+                        buf = &buf[offset0..];
+                    )*
+
+                    if !buf.is_empty() {
+                        return Err(TupleError::InvalidData);
+                    }
+
+                    Ok(out)
+                }
+            }
+        )+
+    }
+}
+
+tuple_impls! {
+    1 => (0 T0)
+    2 => (0 T0 1 T1)
+    3 => (0 T0 1 T1 2 T2)
+    4 => (0 T0 1 T1 2 T2 3 T3)
+    5 => (0 T0 1 T1 2 T2 3 T3 4 T4)
+    6 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5)
+    7 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6)
+    8 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7)
+    9 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8)
+    10 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9)
+    11 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10)
+    12 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TupleValue(pub Vec<SingleValue>);
+
+impl Tuple for TupleValue {
+    fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        for item in self.0.iter() {
+            item.encode(w)?;
+        }
+        Ok(())
+    }
+
+    fn decode(buf: &[u8]) -> Result<Self> {
+        let mut data = buf;
+        let mut v = Vec::new();
+        while !data.is_empty() {
+            let (s, offset): (SingleValue, _) = Single::decode(data)?;
+            v.push(s);
+            data = &data[offset..];
+        }
+        Ok(TupleValue(v))
+    }
+}

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -11,7 +11,7 @@
 pub mod single;
 
 use std::{self, io::Write, string::FromUtf8Error};
-use self::single::{Single, SingleValue};
+use self::single::Single;
 
 #[derive(Debug, Fail)]
 pub enum Error {
@@ -97,7 +97,7 @@ tuple_impls! {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Value(pub Vec<SingleValue>);
+pub struct Value(pub Vec<single::Value>);
 
 impl Tuple for Value {
     fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -111,7 +111,7 @@ impl Tuple for Value {
         let mut data = buf;
         let mut v = Vec::new();
         while !data.is_empty() {
-            let (s, offset): (SingleValue, _) = Single::decode(data)?;
+            let (s, offset): (single::Value, _) = Single::decode(data)?;
             v.push(s);
             data = &data[offset..];
         }

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -97,9 +97,9 @@ tuple_impls! {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct TupleValue(pub Vec<SingleValue>);
+pub struct Value(pub Vec<SingleValue>);
 
-impl Tuple for TupleValue {
+impl Tuple for Value {
     fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
         for item in self.0.iter() {
             item.encode(w)?;
@@ -115,6 +115,6 @@ impl Tuple for TupleValue {
             v.push(s);
             data = &data[offset..];
         }
-        Ok(TupleValue(v))
+        Ok(Value(v))
     }
 }

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -14,7 +14,7 @@ use std::{self, io::Write, string::FromUtf8Error};
 use self::single::{Single, SingleValue};
 
 #[derive(Debug, Fail)]
-pub enum TupleError {
+pub enum Error {
     #[fail(display = "Unexpected end of file")]
     EOF,
     #[fail(display = "Invalid type: {}", value)]
@@ -25,11 +25,11 @@ pub enum TupleError {
     FromUtf8Error(FromUtf8Error),
 }
 
-type Result<T> = std::result::Result<T, TupleError>;
+type Result<T> = std::result::Result<T, Error>;
 
-impl From<FromUtf8Error> for TupleError {
+impl From<FromUtf8Error> for Error {
     fn from(error: FromUtf8Error) -> Self {
-        TupleError::FromUtf8Error(error)
+        Error::FromUtf8Error(error)
     }
 }
 
@@ -71,7 +71,7 @@ macro_rules! tuple_impls {
                     )*
 
                     if !buf.is_empty() {
-                        return Err(TupleError::InvalidData);
+                        return Err(Error::InvalidData);
                     }
 
                     Ok(out)

--- a/foundationdb/src/tuple/single.rs
+++ b/foundationdb/src/tuple/single.rs
@@ -1,6 +1,6 @@
 use std::{self, io::Write};
 
-use super::{Error, TupleValue, Result};
+use tuple::{self, Error, Result};
 use byteorder::{self, ByteOrder};
 
 /// Various tuple types
@@ -39,7 +39,7 @@ pub enum SingleValue {
     Empty,
     Bytes(Vec<u8>),
     Str(String),
-    Nested(TupleValue),
+    Nested(tuple::Value),
     Int(i64),
     Float(f32),
     Double(f64),
@@ -474,7 +474,7 @@ impl Single for SingleValue {
             }
             NESTED => {
                 let (v, offset) = Single::decode(buf)?;
-                Ok((SingleValue::Nested(TupleValue(v)), offset))
+                Ok((SingleValue::Nested(tuple::Value(v)), offset))
             }
             val => {
                 if val >= NEGINTSTART && val <= POSINTEND {
@@ -492,7 +492,7 @@ impl Single for SingleValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tuple::Tuple;
+    use tuple::{Tuple, Value as TupleValue};
 
     fn test_round_trip<S>(val: S, buf: &[u8])
     where

--- a/foundationdb/src/tuple/single.rs
+++ b/foundationdb/src/tuple/single.rs
@@ -47,7 +47,7 @@ pub enum Value {
     Uuid(Uuid),
 }
 
-trait SingleType: Copy {
+trait Type: Copy {
     /// verifies the value matches this type
     fn expect(self, value: u8) -> Result<()>;
 
@@ -108,7 +108,7 @@ fn bisect_left(val: i64) -> usize {
     SIZE_LIMITS.iter().position(|v| val <= *v).unwrap_or(8)
 }
 
-impl SingleType for u8 {
+impl Type for u8 {
     /// verifies the value matches this type
     fn expect(self, value: u8) -> Result<()> {
         if self == value {


### PR DESCRIPTION
Refactors the `tuple` module to:-

* Split `Single` into separate `Encode` and `Decode` traits
* Split `Tuple` into separate `Encode` and `Decode` traits
* Extract "single" types into `tuple::single`
* Rename `TupleError`, `TupleValue`, `SingleValue` and `SingleType` to conform to Rust API guidelines
