### PR TITLE
dedup Tuple::{Decode,Encode} and Item::{Decode,Encode}

### DIFF
--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -176,7 +176,7 @@ impl Instr {
     fn from(data: &[u8]) -> Self {
         use InstrCode::*;
 
-        let tup: tuple::Value = tuple::Decode::decode(data).unwrap();
+        let tup: tuple::Value = tuple::Decode::decode_full(data).unwrap();
         let cmd = match tup.0[0] {
             item::Value::Str(ref s) => s.clone(),
             _ => panic!("unexpected instr"),
@@ -191,7 +191,7 @@ impl Instr {
 
         let code = match cmd {
             "PUSH" => {
-                let data = item::Encode::encode_to_vec(&tup.0[1]);
+                let data = tup.0[1].encode_to_vec();
                 Push(data)
             }
             "DUP" => Dup,
@@ -280,13 +280,13 @@ impl StackItem {
 
         //TODO: wait
         match self.fut.unwrap().wait() {
-            Ok((_trx, data)) => item::Encode::encode_to_vec(&data),
+            Ok((_trx, data)) => data.encode_to_vec(),
             Err(e) => {
                 let code = format!("{}", e.code());
                 let tup = (b"ERROR".to_vec(), code.into_bytes());
                 debug!("ERROR: {:?}", e);
-                let bytes = tuple::Encode::encode_to_vec(&tup);
-                item::Encode::encode_to_vec(&bytes)
+                let bytes = tup.encode_to_vec();
+                bytes.encode_to_vec()
             }
         }
     }
@@ -379,10 +379,10 @@ impl StackMachine {
 
     fn pop_item<S>(&mut self) -> S
     where
-        S: item::Decode,
+        S: Decode,
     {
         let data = self.pop().data();
-        match item::Decode::decode_full(&data) {
+        match Decode::decode_full(&data) {
             Ok(v) => v,
             Err(e) => {
                 panic!("failed to decode item {:?}: {:?}", data, e);
@@ -404,9 +404,9 @@ impl StackMachine {
 
     fn push_item<S>(&mut self, number: usize, s: &S)
     where
-        S: item::Encode,
+        S: Encode,
     {
-        let data = item::Encode::encode_to_vec(s);
+        let data = s.encode_to_vec();
         self.push(number, data);
     }
 
@@ -600,8 +600,8 @@ impl StackMachine {
                                     continue;
                                 }
                             }
-                            item::Encode::encode(&key.to_vec(), &mut out).expect("failed to encode");
-                            item::Encode::encode(&value.to_vec(), &mut out).expect("failed to encode");
+                            key.to_vec().encode(&mut out).expect("failed to encode");
+                            value.to_vec().encode(&mut out).expect("failed to encode");
                         }
                         Ok(out)
                     })
@@ -722,8 +722,8 @@ impl StackMachine {
                 let mut data = data.as_slice();
 
                 while !data.is_empty() {
-                    let (val, offset): (item::Value, _) = item::Decode::decode(data).unwrap();
-                    let bytes = item::Encode::encode_to_vec(&val);
+                    let (val, offset): (item::Value, _) = Decode::decode(data).unwrap();
+                    let bytes = val.encode_to_vec();
                     self.push_item(number, &bytes);
                     data = &data[offset..];
                 }

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -15,7 +15,7 @@
 //! general guidance on subspace usage, see the Subspaces section of the Developer Guide
 //! (https://apple.github.io/foundationdb/developer-guide.html#subspaces).
 
-use tuple::{self, Encode, Decode};
+use tuple::{self, Decode, Encode};
 
 /// Subspace represents a well-defined region of keyspace in a FoundationDB database.
 #[derive(Debug, Clone)]
@@ -72,7 +72,7 @@ impl Subspace {
             return Err(tuple::Error::InvalidData);
         }
         let key = &key[self.prefix.len()..];
-        Decode::decode(&key)
+        Decode::decode_full(&key)
     }
 
     /// `is_start_of` returns true if the provided key starts with the prefix of this Subspace,

--- a/foundationdb/src/tuple/item.rs
+++ b/foundationdb/src/tuple/item.rs
@@ -1,7 +1,7 @@
 use std::{self, io::Write};
 
-use tuple::{self, Error, Result};
 use byteorder::{self, ByteOrder};
+use tuple::{self, Decode, Encode, Error, Result};
 
 /// Various tuple types
 const NIL: u8 = 0x00;
@@ -140,28 +140,6 @@ impl Type for u8 {
 
     fn write<W: Write>(self, w: &mut W) -> std::io::Result<()> {
         w.write_all(&[self])
-    }
-}
-
-pub trait Encode {
-    fn encode<W: Write>(&self, _w: &mut W) -> std::io::Result<()>;
-    fn encode_to_vec(&self) -> Vec<u8> {
-        let mut v = Vec::new();
-        // `self.encode` should not fail because underlying `Write` does not return error.
-        self.encode(&mut v)
-            .expect("item encoding should never fail");
-        v
-    }
-}
-
-pub trait Decode: Sized {
-    fn decode(buf: &[u8]) -> Result<(Self, usize)>;
-    fn decode_full(buf: &[u8]) -> Result<Self> {
-        let (val, offset) = Self::decode(buf)?;
-        if offset != buf.len() {
-            return Err(Error::InvalidData);
-        }
-        Ok(val)
     }
 }
 
@@ -595,10 +573,7 @@ mod tests {
             Value::Nested(TupleValue(vec![
                 Value::Bytes(vec![0]),
                 Value::Empty,
-                Value::Nested(TupleValue(vec![
-                    Value::Bytes(vec![0]),
-                    Value::Empty,
-                ])),
+                Value::Nested(TupleValue(vec![Value::Bytes(vec![0]), Value::Empty])),
             ])),
             &[5, 1, 0, 255, 0, 0, 255, 5, 1, 0, 255, 0, 0, 255, 0, 0],
         );


### PR DESCRIPTION
It was annoying me that these traits were nearly identical.

Now Item and Tuple implement the same traits. It reduces some annoying references that were occurring in the code.