### PR TITLE
encode some borrowed types

### DIFF
--- a/foundationdb/src/tuple/element.rs
+++ b/foundationdb/src/tuple/element.rs
@@ -147,6 +147,12 @@ impl Type for u8 {
     }
 }
 
+impl<'a, T: Encode> Encode for &'a T {
+    fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        T::encode(self, w)
+    }
+}
+
 impl Encode for bool {
     fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
         if *self {
@@ -209,6 +215,13 @@ impl Decode for Uuid {
         uuid.copy_from_slice(&buf[1..17]);
 
         Ok((Uuid::from_uuid_bytes(uuid), 17))
+    }
+}
+
+impl<'a> Encode for &'a str {
+    fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        STRING.write(w)?;
+        encode_bytes(w, self.as_bytes())
     }
 }
 
@@ -288,6 +301,13 @@ impl Decode for Vec<Element> {
 
         // skip the final null
         Ok((tuples, len - buf.len()))
+    }
+}
+
+impl<'a> Encode for &'a [u8] {
+    fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        BYTES.write(w)?;
+        encode_bytes(w, self)
     }
 }
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -57,7 +57,7 @@ macro_rules! tuple_impls {
         $(
             impl<$($name),+> Encode for ($($name,)+)
             where
-                $($name: Encode + Default,)+
+                $($name: Encode,)+
             {
                 #[allow(non_snake_case, unused_assignments, deprecated)]
                 fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn test_encode_tuple_ty() {
-        let tup = (String::from("hello"), b"world".to_vec());
+        let tup = ("hello", b"world".to_vec());
 
         assert_eq!(
             &[2, 104, 101, 108, 108, 111, 0, 1, 119, 111, 114, 108, 100, 0],

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -15,7 +15,7 @@ pub use self::element::Element;
 use std::{self, io::Write, string::FromUtf8Error};
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Tuple<'a>(pub Vec<Element<'a>>);
+pub struct Tuple(pub Vec<Element>);
 
 #[derive(Debug, Fail)]
 pub enum Error {
@@ -111,7 +111,7 @@ tuple_impls! {
     12 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11)
 }
 
-impl<'a> Encode for Tuple<'a> {
+impl Encode for Tuple {
     fn encode<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
         for element in self.0.iter() {
             element.encode(w)?;
@@ -120,7 +120,7 @@ impl<'a> Encode for Tuple<'a> {
     }
 }
 
-impl<'a> Decode for Tuple<'a> {
+impl Decode for Tuple {
     fn decode(buf: &[u8]) -> Result<(Self, usize)> {
         let mut data = buf;
         let mut v = Vec::new();
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn test_encode_tuple_ty() {
-        let tup = ("hello", b"world".to_vec());
+        let tup = (String::from("hello"), b"world".to_vec());
 
         assert_eq!(
             &[2, 104, 101, 108, 108, 111, 0, 1, 119, 111, 114, 108, 100, 0],


### PR DESCRIPTION
* Reverts previous `&str` encoding. See https://github.com/bluejekyll/foundationdb-rs/pull/71#issuecomment-386812699.
* Implements `Encode` for `&str` and `&[u8]`
* Adds a blanket `Encode` implementation for all borrowed types that implement `Encode`