### PR TITLE
Subspace tests for tuple variants

### DIFF
--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -15,6 +15,7 @@
 //! The Rust API Client has been implemented to use the Rust futures crate, and should work within that ecosystem (suchas Tokio). See Rust [futures](https://docs.rs/crate/futures/0.1.21) documentation.
 
 use std;
+use std::ops::Deref;
 
 use foundationdb_sys as fdb;
 use futures;
@@ -103,9 +104,11 @@ impl<'a> KeyValues<'a> {
         self.more
     }
 }
-//TODO: maybe `as_slice()` for just `keyvalues()`? `as_ref()` is not intuitive in this case...
-impl<'a> AsRef<[KeyValue<'a>]> for KeyValues<'a> {
-    fn as_ref(&self) -> &[KeyValue<'a>] {
+
+impl<'a> Deref for KeyValues<'a> {
+    type Target = [KeyValue<'a>];
+
+    fn deref(&self) -> &Self::Target {
         self.keyvalues
     }
 }

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -20,6 +20,7 @@ use error::{self, *};
 use future::*;
 use keyselector::*;
 use options;
+use subspace::Subspace;
 use tuple;
 
 /// In FoundationDB, a transaction is a mutable snapshot of a database.
@@ -102,14 +103,9 @@ impl RangeOptionBuilder {
     /// Create new builder with a tuple as a prefix
     pub fn from_tuple<T>(tup: &T) -> Self
     where
-        T: tuple::Encode,
+        T: tuple::Encode + ?Sized,
     {
-        let bytes = tuple::Encode::encode_to_vec(tup);
-        let mut begin = bytes.clone();
-        begin.push(0x00);
-
-        let mut end = bytes;
-        end.push(0xff);
+        let (begin, end) = Subspace::from(tup).range();
 
         Self::new(
             KeySelector::first_greater_or_equal(&begin),

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -10,9 +10,10 @@
 
 mod element;
 
-pub use self::element::Element;
-
 use std::{self, io::Write, string::FromUtf8Error};
+
+pub use self::element::Element;
+use subspace::Subspace;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Tuple(pub Vec<Element>);
@@ -38,6 +39,12 @@ pub trait Encode {
         self.encode(&mut v)
             .expect("tuple encoding should never fail");
         v
+    }
+}
+
+impl<'a, E: Encode + ?Sized> From<&'a E> for Subspace {
+    fn from(encode: &'a E) -> Self {
+        Subspace::new(encode)
     }
 }
 
@@ -178,5 +185,15 @@ mod tests {
             &[2, 104, 101, 108, 108, 111, 0, 1, 119, 111, 114, 108, 100, 0],
             Encode::encode_to_vec(&tup).as_slice()
         );
+    }
+
+    #[test]
+    fn test_eq() {
+        assert_eq!(
+            "string".encode_to_vec(),
+            "string".to_string().encode_to_vec()
+        );
+
+        assert_eq!("string".encode_to_vec(), ("string",).encode_to_vec());
     }
 }


### PR DESCRIPTION
- changed `KeyValues` to impl Deref for `[KeyValue]`
- cleaned up some range creations
- added some more tuple tests to Subspace to verify tuple variations as beginnings of keys