### PR TITLE
Allow the association of other errors to FdbError

### DIFF
--- a/foundationdb-bench/src/bin/fdb-bench.rs
+++ b/foundationdb-bench/src/bin/fdb-bench.rs
@@ -73,12 +73,12 @@ impl BenchRunner {
     }
 
     //TODO: impl future
-    fn run(self) -> Box<Future<Item = (), Error = FdbError>> {
+    fn run(self) -> Box<Future<Item = (), Error = Error>> {
         Box::new(loop_fn(self, Self::step))
     }
 
     //TODO: impl future
-    fn step(mut self) -> Box<Future<Item = Loop<(), Self>, Error = FdbError>> {
+    fn step(mut self) -> Box<Future<Item = Loop<(), Self>, Error = Error>> {
         use rand::Rng;
 
         let trx = self.trx.take().unwrap();
@@ -153,7 +153,7 @@ impl Bench {
         &self,
         r: std::ops::Range<usize>,
         counter: Counter,
-    ) -> Box<Future<Item = (), Error = FdbError>> {
+    ) -> Box<Future<Item = (), Error = Error>> {
         let runners = r.into_iter()
             .map(|n| {
                 // With deterministic Rng, benchmark with same parameters will overwrite same set

--- a/foundationdb-gen/src/bin/foundationdb-options-gen.rs
+++ b/foundationdb-gen/src/bin/foundationdb-options-gen.rs
@@ -111,7 +111,7 @@ impl FdbScope {
 
         let mut s = String::new();
         s += &format!(
-            "pub unsafe fn apply(&self{}) -> std::result::Result<(), error::FdbError> {{\n",
+            "pub unsafe fn apply(&self{}) -> std::result::Result<(), error::Error> {{\n",
             first_arg
         );
         s += "let code = self.code();\n";
@@ -159,7 +159,7 @@ impl FdbScope {
         }
 
         s += "};\n";
-        s += "if err != 0 { Err(error::FdbError::from(err)) } else { Ok(()) }\n";
+        s += "if err != 0 { Err(error::Error::from(err)) } else { Ok(()) }\n";
         s += "}\n";
 
         s

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -177,7 +177,7 @@ impl Instr {
         use InstrCode::*;
 
         let tup: Tuple = Decode::decode_full(data).unwrap();
-        let cmd = match tup.0[0] {
+        let cmd = match tup[0] {
             Element::String(ref s) => s.clone(),
             _ => panic!("unexpected instr"),
         };
@@ -191,7 +191,7 @@ impl Instr {
 
         let code = match cmd {
             "PUSH" => {
-                let data = tup.0[1].encode_to_vec();
+                let data = tup[1].encode_to_vec();
                 Push(data)
             }
             "DUP" => Dup,

--- a/foundationdb/src/cluster.rs
+++ b/foundationdb/src/cluster.rs
@@ -46,7 +46,7 @@ impl Cluster {
     /// Returns an `FdbFuture` which will be set to an `Database` object.
     ///
     /// TODO: impl Future
-    pub fn create_database(&self) -> Box<Future<Item = Database, Error = FdbError>> {
+    pub fn create_database(&self) -> Box<Future<Item = Database, Error = Error>> {
         let f = unsafe {
             let f_db = fdb::fdb_cluster_create_database(self.inner.inner, b"DB" as *const _, 2);
             let cluster = self.clone();
@@ -64,7 +64,7 @@ pub struct ClusterGet {
 }
 impl Future for ClusterGet {
     type Item = Cluster;
-    type Error = FdbError;
+    type Error = Error;
 
     fn poll(&mut self) -> Result<Async<Self::Item>> {
         match self.inner.poll() {

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -65,39 +65,55 @@ impl Database {
     /// It might retry indefinitely if the transaction is highly contentious. It is recommended to
     /// set `TransactionOption::RetryLimit` or `TransactionOption::SetTimeout` on the transaction
     /// if the task need to be guaranteed to finish.
-    pub fn transact<F, Fut, Item, E>(&self, f: F) -> Box<Future<Item = Fut::Item, Error = Error>>
+    pub fn transact<F, Fut, Item, E>(&self, f: F) -> Box<Future<Item = Fut::Item, Error = E>>
     where
         F: FnMut(Transaction) -> Fut + 'static,
         Fut: Future<Item = Item, Error = E> + 'static,
         Item: 'static,
-        E: Into<Error>,
+        E: From<Error> + Send + Sync + 'static,
     {
+        // This will be used to temporarily capture the internal error of the FnMut, F.
+        enum EitherError<E> {
+            Fdb(Error),
+            Other(E),
+        }
+
         let db = self.clone();
 
-        let f = result(db.create_trx()).and_then(|trx| {
-            loop_fn((trx, f), |(trx, mut f)| {
-                let trx0 = trx.clone();
-                f(trx.clone())
-                    .map_err(|e| Into::<Error>::into(e))
-                    .and_then(move |res| {
-                        // try to commit the transaction
-                        trx0.commit().map(|_| res)
-                    })
-                    .then(|res| match res {
-                        Ok(v) => {
-                            // committed
-                            Ok(Loop::Break(v))
-                        }
-                        Err(e) => {
-                            if e.should_retry() {
-                                Ok(Loop::Continue((trx, f)))
-                            } else {
-                                Err(e)
+        let f = result(db.create_trx())
+            // capture any initial FdbError
+            .map_err(EitherError::Fdb)
+            .and_then(|trx| {
+                loop_fn((trx, f), |(trx, mut f)| {
+                    let trx0 = trx.clone();
+                    f(trx.clone())
+                        .map_err(EitherError::Other)
+                        .and_then(move |res| {
+                            // try to commit the transaction
+                            trx0.commit().map(|_| res).map_err(EitherError::Fdb)
+                        })
+                        .then(|res| match res {
+                            Ok(v) => {
+                                // committed
+                                Ok(Loop::Break(v))
                             }
-                        }
-                    })
+                            Err(EitherError::Fdb(e)) => {
+                                if e.should_retry() {
+                                    Ok(Loop::Continue((trx, f)))
+                                } else {
+                                    Err(EitherError::Fdb(e))
+                                }
+                            }
+                            // Eearly return on internal error...
+                            Err(EitherError::Other(e)) => Err(EitherError::Other(e)),
+                        })
+                })
             })
-        });
+            // finally unwrap any error into the final error result...
+            .map_err(|e| match e {
+                EitherError::Fdb(e) => E::from(e),
+                EitherError::Other(e) => e,
+            });
 
         Box::new(f)
     }

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -8,91 +8,160 @@
 
 //! Error types for the Fdb crate
 
-use options;
 use std;
 use std::ffi::CStr;
+use std::fmt::{self, Display};
+
+use failure::{self, Backtrace, Context, Fail};
 
 use foundationdb_sys as fdb_sys;
+use options;
 
 pub(crate) fn eval(error_code: fdb_sys::fdb_error_t) -> Result<()> {
     let rust_code = error_code as i32;
     if rust_code == 0 {
         Ok(())
     } else {
-        Err(FdbError::from(error_code))
+        Err(Error::from(error_code))
     }
 }
 
-/// An error from Fdb with associated code and message
-#[derive(Debug, Fail)]
-#[fail(display = "FoundationDB error({}): {}", error_code, error_str)]
-pub struct FdbError {
-    error_code: i32,
-    error_str: &'static str,
-
+/// The Standard Error type of FoundationDB
+#[derive(Debug)]
+pub struct Error {
+    kind: Context<ErrorKind>,
     // Not all retryable error should be retried. For example, error_code=1020 transaction conflict
-    // error is always retryable (so `FdbError::is_retryable` always returns `true`), while it
+    // error is always retryable (so `Error::is_retryable` always returns `true`), while it
     // should not be retried if `TransactionOption::RetryLimit` is exceeded. So we should keep
     // track whether the error should be retried or not.
     should_retry: bool,
 }
 
-/// An Fdb Result type
-pub type Result<T> = std::result::Result<T, FdbError>;
+/// An error from Fdb with associated code and message
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    /// Errors that originate from the FoundationDB layers
+    #[fail(display = "FoundationDB error({}): {}", error_code, error_str)]
+    Fdb {
+        /// The FoundationDB error code
+        error_code: i32,
+        /// The error string as defined by FoundationDB
+        error_str: &'static str,
+    },
+    /// Other errors not directly attributed to the FoundationDB layers
+    #[fail(display = "FoundationDB-RS error: {}", error)]
+    Other {
+        /// The cause of this error
+        error: failure::Error,
+    },
+}
 
-impl FdbError {
-    /// Converts from the raw Fdb error code into an `FdbError`
+/// An Fdb Result type
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.kind.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.kind.backtrace()
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.kind, f)
+    }
+}
+
+impl From<failure::Error> for Error {
+    fn from(error: failure::Error) -> Self {
+        Error::from_other(error)
+    }
+}
+
+impl Error {
+    /// Converts from the raw Fdb error code into an `Error`
     pub fn from(error_code: fdb_sys::fdb_error_t) -> Self {
         let error_str = unsafe { CStr::from_ptr(fdb_sys::fdb_get_error(error_code)) };
 
-        FdbError {
-            error_code: error_code as i32,
-            error_str: error_str
-                .to_str()
-                .expect("bad error string from FoundationDB"),
+        Error {
+            kind: Context::new(ErrorKind::Fdb {
+                error_code: error_code as i32,
+                error_str: error_str
+                    .to_str()
+                    .expect("bad error string from FoundationDB"),
+            }),
+            should_retry: false,
+        }
+    }
+
+    /// Creates an error from another error or failure
+    pub fn from_other(error: failure::Error) -> Self {
+        Error {
+            kind: Context::new(ErrorKind::Other { error }),
             should_retry: false,
         }
     }
 
     /// Indicates the transaction may have succeeded, though not in a way the system can verify.
     pub fn is_maybe_committed(&self) -> bool {
-        let check = unsafe {
-            fdb_sys::fdb_error_predicate(
-                options::ErrorPredicate::MaybeCommitted.code() as i32,
-                self.error_code,
-            ) as i32
-        };
+        match *self.kind.get_context() {
+            ErrorKind::Fdb { error_code, .. } => {
+                let check = unsafe {
+                    fdb_sys::fdb_error_predicate(
+                        options::ErrorPredicate::MaybeCommitted.code() as i32,
+                        error_code,
+                    ) as i32
+                };
 
-        check != 0
+                check != 0
+            }
+            _ => false,
+        }
     }
 
     /// Indicates the operations in the transactions should be retried because of transient error.
     pub fn is_retryable(&self) -> bool {
-        let check = unsafe {
-            fdb_sys::fdb_error_predicate(
-                options::ErrorPredicate::Retryable.code() as i32,
-                self.error_code,
-            ) as i32
-        };
+        match *self.kind.get_context() {
+            ErrorKind::Fdb { error_code, .. } => {
+                let check = unsafe {
+                    fdb_sys::fdb_error_predicate(
+                        options::ErrorPredicate::Retryable.code() as i32,
+                        error_code,
+                    ) as i32
+                };
 
-        check != 0
+                check != 0
+            }
+            _ => false,
+        }
     }
 
     /// Indicates the transaction has not committed, though in a way that can be retried.
     pub fn is_retryable_not_committed(&self) -> bool {
-        let check = unsafe {
-            fdb_sys::fdb_error_predicate(
-                options::ErrorPredicate::RetryableNotCommitted.code() as i32,
-                self.error_code,
-            ) as i32
-        };
+        match *self.kind.get_context() {
+            ErrorKind::Fdb { error_code, .. } => {
+                let check = unsafe {
+                    fdb_sys::fdb_error_predicate(
+                        options::ErrorPredicate::RetryableNotCommitted.code() as i32,
+                        error_code,
+                    ) as i32
+                };
 
-        check != 0
+                check != 0
+            }
+            _ => false,
+        }
     }
 
     /// Error code
     pub fn code(&self) -> i32 {
-        self.error_code
+        match *self.kind.get_context() {
+            ErrorKind::Fdb { error_code, .. } => error_code,
+            _ => 4000,
+        }
     }
 
     pub(crate) fn set_should_retry(&mut self, should_retry: bool) {

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -16,6 +16,7 @@ use failure::{self, Backtrace, Context, Fail};
 
 use foundationdb_sys as fdb_sys;
 use options;
+use tuple;
 
 pub(crate) fn eval(error_code: fdb_sys::fdb_error_t) -> Result<()> {
     let rust_code = error_code as i32;
@@ -53,6 +54,12 @@ pub enum ErrorKind {
     Other {
         /// The cause of this error
         error: failure::Error,
+    },
+    /// Encoding/Decoding errors related to Tuple
+    #[fail(display = "Internal error with tuple encoding/decoding: {}", error)]
+    Tuple {
+        /// The cause of this error
+        error: tuple::Error,
     },
 }
 

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -21,7 +21,7 @@ use foundationdb_sys as fdb;
 use futures;
 use futures::Async;
 
-use error::{self, FdbError, Result};
+use error::{self, Error, Result};
 
 /// An opaque type that represents a Future in the FoundationDB C API.
 pub(crate) struct FdbFuture {
@@ -51,7 +51,7 @@ impl Drop for FdbFuture {
 
 impl futures::Future for FdbFuture {
     type Item = FdbFutureResult;
-    type Error = FdbError;
+    type Error = Error;
 
     fn poll(&mut self) -> std::result::Result<Async<Self::Item>, Self::Error> {
         let f = self.f.expect("cannot poll after resolve");

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -133,7 +133,6 @@ pub mod network;
 pub mod options;
 pub mod subspace;
 pub mod transaction;
-#[allow(missing_docs)]
 pub mod tuple;
 
 //move to prelude?

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -138,6 +138,7 @@ pub mod tuple;
 //move to prelude?
 pub use cluster::Cluster;
 pub use database::Database;
+pub use error::Error;
 pub use transaction::Transaction;
 
 /// Initialize the FoundationDB Client API, this can only be called once per process.

--- a/foundationdb/src/options.rs
+++ b/foundationdb/src/options.rs
@@ -147,7 +147,7 @@ impl NetworkOption {
             }
         }
     }
-    pub unsafe fn apply(&self) -> std::result::Result<(), error::FdbError> {
+    pub unsafe fn apply(&self) -> std::result::Result<(), error::Error> {
         let code = self.code();
         let err = match *self {
             NetworkOption::LocalAddress(ref v) => {
@@ -224,7 +224,7 @@ impl NetworkOption {
             }
         };
         if err != 0 {
-            Err(error::FdbError::from(err))
+            Err(error::Error::from(err))
         } else {
             Ok(())
         }
@@ -267,7 +267,7 @@ impl DatabaseOption {
     pub unsafe fn apply(
         &self,
         target: *mut fdb::FDBDatabase,
-    ) -> std::result::Result<(), error::FdbError> {
+    ) -> std::result::Result<(), error::Error> {
         let code = self.code();
         let err = match *self {
             DatabaseOption::LocationCacheSize(v) => {
@@ -286,7 +286,7 @@ impl DatabaseOption {
             }
         };
         if err != 0 {
-            Err(error::FdbError::from(err))
+            Err(error::Error::from(err))
         } else {
             Ok(())
         }
@@ -437,7 +437,7 @@ impl TransactionOption {
     pub unsafe fn apply(
         &self,
         target: *mut fdb::FDBTransaction,
-    ) -> std::result::Result<(), error::FdbError> {
+    ) -> std::result::Result<(), error::Error> {
         let code = self.code();
         let err = match *self {
             TransactionOption::CausalWriteRisky => {
@@ -532,7 +532,7 @@ impl TransactionOption {
             }
         };
         if err != 0 {
-            Err(error::FdbError::from(err))
+            Err(error::Error::from(err))
         } else {
             Ok(())
         }

--- a/foundationdb/src/tuple/element.rs
+++ b/foundationdb/src/tuple/element.rs
@@ -3,7 +3,7 @@ use std::{self, io::Write};
 use uuid::Uuid;
 
 use byteorder::{self, ByteOrder};
-use tuple::{Tuple, Decode, Encode, Error, Result};
+use tuple::{Decode, Encode, Error, Result, Tuple};
 
 /// Various tuple types
 const NIL: u8 = 0x00;
@@ -34,16 +34,26 @@ const SIZE_LIMITS: &[i64] = &[
     (1 << (7 * 8)) - 1,
 ];
 
+/// A single tuple element
 #[derive(Clone, Debug, PartialEq)]
 pub enum Element {
+    /// Corresponse with nothing, ie the Nil byte
     Empty,
+    /// A sequence of bytes to be written to the stream
     Bytes(Vec<u8>),
+    /// A string
     String(String),
+    /// A recursive Tuple
     Tuple(Tuple),
+    /// An i64
     I64(i64),
+    /// An f32
     F32(f32),
+    /// An f64
     F64(f64),
+    /// A bool
     Bool(bool),
+    /// A UUID, requires the uuid feature/library
     #[cfg(feature = "uuid")]
     Uuid(Uuid),
     #[doc(hidden)]

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -238,39 +238,4 @@ mod tests {
 
         assert_eq!("string".encode_to_vec(), ("string",).encode_to_vec());
     }
-
-    #[test]
-    fn test_recursive_tuple() {
-        assert_eq!(
-            &("one", ("two", 42)).encode_to_vec(),
-            &[2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42]
-        );
-        assert_eq!(
-            &("one", ("two", 42, ("three", 33))).encode_to_vec(),
-            &[
-                2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42, 2, 116, 104, 114, 101, 101, 0,
-                21, 33,
-            ]
-        );
-
-        let two_decode = <(String, (String, i64))>::decode_full(&[
-            2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42,
-        ]).expect("failed two");
-
-        // TODO: can we get eq for borrows of the inner types?
-        assert_eq!(("one".to_string(), ("two".to_string(), 42)), two_decode);
-
-        let three_decode = <(String, (String, i64, (String, i64)))>::decode_full(&[
-            2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42, 2, 116, 104, 114, 101, 101, 0, 21,
-            33,
-        ]).expect("failed three");
-
-        assert_eq!(
-            &(
-                "one".to_string(),
-                ("two".to_string(), 42, ("three".to_string(), 33))
-            ),
-            &three_decode
-        );
-    }
 }

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -238,4 +238,39 @@ mod tests {
 
         assert_eq!("string".encode_to_vec(), ("string",).encode_to_vec());
     }
+
+    #[test]
+    fn test_recursive_tuple() {
+        assert_eq!(
+            &("one", ("two", 42)).encode_to_vec(),
+            &[2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42]
+        );
+        assert_eq!(
+            &("one", ("two", 42, ("three", 33))).encode_to_vec(),
+            &[
+                2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42, 2, 116, 104, 114, 101, 101, 0,
+                21, 33,
+            ]
+        );
+
+        let two_decode = <(String, (String, i64))>::decode_full(&[
+            2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42,
+        ]).expect("failed two");
+
+        // TODO: can we get eq for borrows of the inner types?
+        assert_eq!(("one".to_string(), ("two".to_string(), 42)), two_decode);
+
+        let three_decode = <(String, (String, i64, (String, i64)))>::decode_full(&[
+            2, 111, 110, 101, 0, 2, 116, 119, 111, 0, 21, 42, 2, 116, 104, 114, 101, 101, 0, 21,
+            33,
+        ]).expect("failed three");
+
+        assert_eq!(
+            &(
+                "one".to_string(),
+                ("two".to_string(), 42, ("three".to_string(), 33))
+            ),
+            &three_decode
+        );
+    }
 }

--- a/foundationdb/tests/atomic.rs
+++ b/foundationdb/tests/atomic.rs
@@ -22,7 +22,7 @@ fn atomic_add(
     db: Database,
     key: &[u8],
     value: i64,
-) -> Box<Future<Item = (), Error = error::FdbError>> {
+) -> Box<Future<Item = (), Error = error::Error>> {
     let trx = match db.create_trx() {
         Ok(trx) => trx,
         Err(e) => return Box::new(err(e)),

--- a/foundationdb/tests/range.rs
+++ b/foundationdb/tests/range.rs
@@ -10,6 +10,7 @@ extern crate futures;
 #[macro_use]
 extern crate lazy_static;
 
+use foundationdb::error::Error;
 use foundationdb::*;
 use futures::future::*;
 use futures::prelude::*;
@@ -46,7 +47,7 @@ fn test_get_range() {
                 .map_err(|(_opt, e)| e)
                 .fold(0, |count, item| {
                     let kvs = item.keyvalues();
-                    Ok(count + kvs.as_ref().len())
+                    Ok::<_, Error>(count + kvs.as_ref().len())
                 })
                 .map(|count| {
                     if count != N {

--- a/foundationdb/tests/transact.rs
+++ b/foundationdb/tests/transact.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/bluejekyll/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate foundationdb;
+extern crate futures;
+#[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
+extern crate failure;
+
+use foundationdb::*;
+use futures::future::*;
+
+mod common;
+
+#[test]
+fn test_transact_error() {
+    common::setup_static();
+    let fut = Cluster::new(foundationdb::default_config_path())
+        .and_then(|cluster| cluster.create_database())
+        .map_err(failure::Error::from)
+        .and_then(|db| db.transact(|_trx| -> Result<(), failure::Error> { bail!("failed") }));
+
+    assert!(fut.wait().is_err(), "should return error");
+}

--- a/foundationdb/tests/watch.rs
+++ b/foundationdb/tests/watch.rs
@@ -78,7 +78,7 @@ fn test_watch_without_commit() {
             // should return error_code=1025, `Operation aborted because the transaction was
             // canceled`
             eprintln!("error as expected: {:?}", e);
-            Ok::<(), error::FdbError>(())
+            Ok::<(), error::Error>(())
         });
 
     fut.wait().expect("failed to run")


### PR DESCRIPTION
To make `transact` a little more flexible, I've added ErrorKind to FdbError.
- renamed FdbError -> Error
- introduced ErrorKind
- introduced a `From<failure::Error>` for ease of conversion
- transact now requires `Into<foundationdb::error::Error>` for it's future error result
- Adds deref `Vec<Element>` to tuple