### PR TITLE
cleanup `subspace`

### DIFF
--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -70,7 +70,7 @@ fn all_classes() -> Vec<String> {
 }
 
 fn init_classes(trx: &Transaction, all_classes: &[String]) {
-    let class_subspace = Subspace::from(&"class");
+    let class_subspace = Subspace::from("class");
     for class in all_classes {
         trx.set(&class_subspace.pack(class), &100_i64.encode_to_vec());
     }
@@ -78,8 +78,8 @@ fn init_classes(trx: &Transaction, all_classes: &[String]) {
 
 fn init(db: &Database, all_classes: &[String]) {
     let trx = db.create_trx().expect("could not create transaction");
-    trx.clear_subspace_range(&("attends",));
-    trx.clear_subspace_range(&("class",));
+    trx.clear_subspace_range(("attends",));
+    trx.clear_subspace_range(("class",));
     init_classes(&trx, all_classes);
 
     trx.commit().wait().expect("failed to initialize data");
@@ -88,7 +88,7 @@ fn init(db: &Database, all_classes: &[String]) {
 fn get_available_classes(db: &Database) -> Vec<String> {
     let trx = db.create_trx().expect("could not create transaction");
 
-    let range = RangeOptionBuilder::from_tuple(&"class");
+    let range = RangeOptionBuilder::from_tuple("class");
 
     trx.get_range(range.build(), 1_024)
         .and_then(|got_range| {
@@ -314,7 +314,7 @@ fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
         thread.join().expect("failed to join thread");
 
         let student_id = format!("s{}", id);
-        let attends_range = RangeOptionBuilder::from_tuple(&("attends", &student_id)).build();
+        let attends_range = RangeOptionBuilder::from_tuple(("attends", &student_id)).build();
 
         for key_value in db.create_trx()
             .unwrap()

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -131,7 +131,7 @@ pub mod network;
 /// Generated configuration types for use with the various `set_option` functions
 #[allow(missing_docs)]
 pub mod options;
-pub mod subspace;
+mod subspace;
 pub mod transaction;
 pub mod tuple;
 
@@ -139,8 +139,8 @@ pub mod tuple;
 pub use cluster::Cluster;
 pub use database::Database;
 pub use error::Error;
-pub use subspace::Subspace;
 pub use transaction::Transaction;
+pub use subspace::Subspace;
 
 /// Initialize the FoundationDB Client API, this can only be called once per process.
 ///

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -24,6 +24,14 @@ pub struct Subspace {
     prefix: Vec<u8>,
 }
 
+impl<E: Encode> From<E> for Subspace {
+    fn from(e: E) -> Self {
+        Self {
+            prefix: e.encode_to_vec(),
+        }
+    }
+}
+
 impl Subspace {
     /// `all` returns the Subspace corresponding to all keys in a FoundationDB database.
     pub fn all() -> Subspace {
@@ -34,13 +42,6 @@ impl Subspace {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         Self {
             prefix: bytes.to_vec(),
-        }
-    }
-
-    /// Returns a new Subspace from the provided tuple encodable.
-    pub fn new<T: Encode>(t: T) -> Self {
-        Self {
-            prefix: t.encode_to_vec(),
         }
     }
 
@@ -105,17 +106,17 @@ mod tests {
 
     #[test]
     fn sub() {
-        let ss0 = Subspace::new((1,));
+        let ss0: Subspace = (1,).into();
         let ss1 = ss0.subspace((2,));
 
-        let ss2 = Subspace::new((1, 2));
+        let ss2: Subspace = (1, 2).into();
 
         assert_eq!(ss1.bytes(), ss2.bytes());
     }
 
     #[test]
     fn pack_unpack() {
-        let ss0 = Subspace::new((1,));
+        let ss0: Subspace = (1,).into();
         let tup = (2, 3);
 
         let packed = ss0.pack(&tup);
@@ -130,8 +131,8 @@ mod tests {
 
     #[test]
     fn is_start_of() {
-        let ss0 = Subspace::new((1,));
-        let ss1 = Subspace::new((2,));
+        let ss0: Subspace = (1,).into();
+        let ss1: Subspace = (2,).into();
         let tup = (2, 3);
 
         assert!(ss0.is_start_of(&ss0.pack(&tup)));
@@ -146,7 +147,7 @@ mod tests {
 
     #[test]
     fn unpack_malformed() {
-        let ss0 = Subspace::new(((),));
+        let ss0: Subspace = ((),).into();
 
         let malformed = {
             let mut v = ss0.bytes().to_vec();
@@ -159,7 +160,7 @@ mod tests {
 
     #[test]
     fn range() {
-        let ss = Subspace::new((1,));
+        let ss: Subspace = (1,).into();
         let tup = (2, 3);
         let packed = ss.pack(&tup);
 

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -106,8 +106,8 @@ mod tests {
 
     #[test]
     fn sub() {
-        let ss0: Subspace = (1,).into();
-        let ss1 = ss0.subspace((2,));
+        let ss0: Subspace = 1.into();
+        let ss1 = ss0.subspace(2);
 
         let ss2: Subspace = (1, 2).into();
 
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn pack_unpack() {
-        let ss0: Subspace = (1,).into();
+        let ss0: Subspace = 1.into();
         let tup = (2, 3);
 
         let packed = ss0.pack(&tup);
@@ -131,8 +131,8 @@ mod tests {
 
     #[test]
     fn is_start_of() {
-        let ss0: Subspace = (1,).into();
-        let ss1: Subspace = (2,).into();
+        let ss0: Subspace = 1.into();
+        let ss1: Subspace = 2.into();
         let tup = (2, 3);
 
         assert!(ss0.is_start_of(&ss0.pack(&tup)));
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn range() {
-        let ss: Subspace = (1,).into();
+        let ss: Subspace = 1.into();
         let tup = (2, 3);
         let packed = ss.pack(&tup);
 

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -6,18 +6,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! subspace provides a convenient way to use FoundationDB tuples to define namespaces for
-//! different categories of data. The namespace is specified by a prefix tuple which is prepended
-//! to all tuples packed by the subspace. When unpacking a key with the subspace, the prefix tuple
-//! will be removed from the result.
-//!
-//! As a best practice, API clients should use at least one subspace for application data. For
-//! general guidance on subspace usage, see the Subspaces section of the Developer Guide
-//! (https://apple.github.io/foundationdb/developer-guide.html#subspaces).
-
 use tuple::{Decode, Encode, Error, Result};
 
-/// Subspace represents a well-defined region of keyspace in a FoundationDB database.
+/// Represents a well-defined region of keyspace in a FoundationDB database
+///
+/// It provides a convenient way to use FoundationDB tuples to define namespaces for
+/// different categories of data. The namespace is specified by a prefix tuple which is prepended
+/// to all tuples packed by the subspace. When unpacking a key with the subspace, the prefix tuple
+/// will be removed from the result.
+///
+/// As a best practice, API clients should use at least one subspace for application data. For
+/// general guidance on subspace usage, see the Subspaces section of the [Developer Guide].
+///
+/// [Developer Guide]: https://apple.github.io/foundationdb/developer-guide.html#subspaces
 #[derive(Debug, Clone)]
 pub struct Subspace {
     prefix: Vec<u8>,

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -106,8 +106,8 @@ mod tests {
 
     #[test]
     fn sub() {
-        let ss0: Subspace = 1.into();
-        let ss1 = ss0.subspace(2);
+        let ss0: Subspace = (1,).into();
+        let ss1 = ss0.subspace((2,));
 
         let ss2: Subspace = (1, 2).into();
 
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn pack_unpack() {
-        let ss0: Subspace = 1.into();
+        let ss0: Subspace = (1,).into();
         let tup = (2, 3);
 
         let packed = ss0.pack(&tup);
@@ -131,8 +131,8 @@ mod tests {
 
     #[test]
     fn is_start_of() {
-        let ss0: Subspace = 1.into();
-        let ss1: Subspace = 2.into();
+        let ss0: Subspace = (1,).into();
+        let ss1: Subspace = (2,).into();
         let tup = (2, 3);
 
         assert!(ss0.is_start_of(&ss0.pack(&tup)));
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn range() {
-        let ss: Subspace = 1.into();
+        let ss: Subspace = (1,).into();
         let tup = (2, 3);
         let packed = ss.pack(&tup);
 

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -21,7 +21,7 @@ use future::*;
 use keyselector::*;
 use options;
 use subspace::Subspace;
-use tuple;
+use tuple::Encode;
 
 /// In FoundationDB, a transaction is a mutable snapshot of a database.
 ///
@@ -101,9 +101,9 @@ impl RangeOptionBuilder {
     }
 
     /// Create new builder with a tuple as a prefix
-    pub fn from_tuple<T>(tup: &T) -> Self
+    pub fn from_tuple<T>(tup: T) -> Self
     where
-        T: tuple::Encode + ?Sized,
+        T: Encode,
     {
         let (begin, end) = Subspace::from(tup).range();
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -14,7 +14,6 @@ use std::ops::{Deref, DerefMut};
 use std::{self, io::Write, string::FromUtf8Error};
 
 pub use self::element::Element;
-use subspace::Subspace;
 
 /// Tuple encoding/decoding related errors
 #[derive(Debug, Fail)]
@@ -73,12 +72,6 @@ pub trait Encode {
         self.encode(&mut v)
             .expect("tuple encoding should never fail");
         v
-    }
-}
-
-impl<E: Encode> From<E> for Subspace {
-    fn from(encode: E) -> Self {
-        Subspace::new(encode)
     }
 }
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -76,8 +76,8 @@ pub trait Encode {
     }
 }
 
-impl<'a, E: Encode + ?Sized> From<&'a E> for Subspace {
-    fn from(encode: &'a E) -> Self {
+impl<E: Encode> From<E> for Subspace {
+    fn from(encode: E) -> Self {
         Subspace::new(encode)
     }
 }


### PR DESCRIPTION
* `Subspace` APIs currently make borrowing mandatory. So instead of simply writing `Subspace::from("start")`, you are forced to write `Subspace::from(&"start")`
* The entire `subspace` module doesn't need to be exported publicly since it's only exposing one struct
* The `From` implementation makes `Subspace::new` redundant