### PR TITLE
track when inside tuples during encoding

### DIFF
--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -78,8 +78,8 @@ fn init_classes(trx: &Transaction, all_classes: &[String]) {
 
 fn init(db: &Database, all_classes: &[String]) {
     let trx = db.create_trx().expect("could not create transaction");
-    trx.clear_subspace_range(&"attends");
-    trx.clear_subspace_range(&"class");
+    trx.clear_subspace_range("attends");
+    trx.clear_subspace_range("class");
     init_classes(&trx, all_classes);
 
     trx.commit().wait().expect("failed to initialize data");
@@ -98,8 +98,7 @@ fn get_available_classes(db: &Database) -> Vec<String> {
                 let count = i64::try_from(key_value.value()).expect("failed to decode count");
 
                 if count > 0 {
-                    let class =
-                        String::try_from(key_value.key()).expect("failed to decode class");
+                    let class = String::try_from(key_value.key()).expect("failed to decode class");
                     available_classes.push(class);
                 }
             }

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -70,7 +70,7 @@ fn all_classes() -> Vec<String> {
 }
 
 fn init_classes(trx: &Transaction, all_classes: &[String]) {
-    let class_subspace = Subspace::from(&"class");
+    let class_subspace = Subspace::from("class");
     for class in all_classes {
         trx.set(&class_subspace.pack(class), &100_i64.to_vec());
     }

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -70,7 +70,7 @@ fn all_classes() -> Vec<String> {
 }
 
 fn init_classes(trx: &Transaction, all_classes: &[String]) {
-    let class_subspace = Subspace::from("class");
+    let class_subspace = Subspace::from(&"class");
     for class in all_classes {
         trx.set(&class_subspace.pack(class), &100_i64.to_vec());
     }
@@ -78,8 +78,8 @@ fn init_classes(trx: &Transaction, all_classes: &[String]) {
 
 fn init(db: &Database, all_classes: &[String]) {
     let trx = db.create_trx().expect("could not create transaction");
-    trx.clear_subspace_range(("attends",));
-    trx.clear_subspace_range(("class",));
+    trx.clear_subspace_range(&"attends");
+    trx.clear_subspace_range(&"class");
     init_classes(&trx, all_classes);
 
     trx.commit().wait().expect("failed to initialize data");

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -600,12 +600,10 @@ impl StackMachine {
                                     continue;
                                 }
                             }
-                            key.to_vec()
-                                .encode(&mut out, false)
-                                .expect("failed to encode");
+                            key.to_vec().encode(&mut out, 0).expect("failed to encode");
                             value
                                 .to_vec()
-                                .encode(&mut out, false)
+                                .encode(&mut out, 0)
                                 .expect("failed to encode");
                         }
                         Ok::<_, Error>(out)
@@ -727,8 +725,10 @@ impl StackMachine {
                 let mut data = data.as_slice();
 
                 while !data.is_empty() {
-                    let (val, offset): (Element, _) = Decode::decode(data, false).unwrap();
+                    let (val, offset): (Element, _) = Decode::decode(data, 0).unwrap();
                     let bytes = val.to_vec();
+
+                    let bytes = val.encode_to_vec();
                     self.push_item(number, &bytes);
                     data = &data[offset..];
                 }

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -727,8 +727,6 @@ impl StackMachine {
                 while !data.is_empty() {
                     let (val, offset): (Element, _) = Decode::decode(data, 0).unwrap();
                     let bytes = val.to_vec();
-
-                    let bytes = val.encode_to_vec();
                     self.push_item(number, &bytes);
                     data = &data[offset..];
                 }

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -600,8 +600,13 @@ impl StackMachine {
                                     continue;
                                 }
                             }
-                            key.to_vec().encode(&mut out).expect("failed to encode");
-                            value.to_vec().encode(&mut out).expect("failed to encode");
+                            key.to_vec()
+                                .encode(&mut out, false)
+                                .expect("failed to encode");
+                            value
+                                .to_vec()
+                                .encode(&mut out, false)
+                                .expect("failed to encode");
                         }
                         Ok::<_, Error>(out)
                     })
@@ -722,7 +727,7 @@ impl StackMachine {
                 let mut data = data.as_slice();
 
                 while !data.is_empty() {
-                    let (val, offset): (Element, _) = Decode::decode(data).unwrap();
+                    let (val, offset): (Element, _) = Decode::decode(data, false).unwrap();
                     let bytes = val.to_vec();
                     self.push_item(number, &bytes);
                     data = &data[offset..];

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -353,7 +353,7 @@ impl StackMachine {
     fn fetch_instr(&self) -> Box<Future<Item = Vec<Instr>, Error = Error>> {
         let db = self.db.clone();
 
-        let prefix = (self.prefix.clone(),);
+        let prefix = self.prefix.clone();
         let f = db.transact(move |trx| {
             let opt = transaction::RangeOptionBuilder::from_tuple(&prefix).build();
             let instrs = Vec::new();

--- a/foundationdb/src/bin/bindingtester.rs
+++ b/foundationdb/src/bin/bindingtester.rs
@@ -600,10 +600,10 @@ impl StackMachine {
                                     continue;
                                 }
                             }
-                            key.to_vec().encode(&mut out, 0).expect("failed to encode");
+                            key.to_vec().encode_to(&mut out).expect("failed to encode");
                             value
                                 .to_vec()
-                                .encode(&mut out, 0)
+                                .encode_to(&mut out)
                                 .expect("failed to encode");
                         }
                         Ok::<_, Error>(out)
@@ -725,7 +725,7 @@ impl StackMachine {
                 let mut data = data.as_slice();
 
                 while !data.is_empty() {
-                    let (val, offset): (Element, _) = Decode::decode(data, 0).unwrap();
+                    let (val, offset): (Element, _) = Decode::decode_from(data).unwrap();
                     let bytes = val.to_vec();
                     self.push_item(number, &bytes);
                     data = &data[offset..];

--- a/foundationdb/src/subspace.rs
+++ b/foundationdb/src/subspace.rs
@@ -26,9 +26,7 @@ pub struct Subspace {
 
 impl<E: Encode> From<E> for Subspace {
     fn from(e: E) -> Self {
-        Self {
-            prefix: e.to_vec(),
-        }
+        Self { prefix: e.to_vec() }
     }
 }
 
@@ -106,8 +104,8 @@ mod tests {
 
     #[test]
     fn sub() {
-        let ss0: Subspace = (1,).into();
-        let ss1 = ss0.subspace((2,));
+        let ss0: Subspace = 1.into();
+        let ss1 = ss0.subspace(2);
 
         let ss2: Subspace = (1, 2).into();
 
@@ -116,7 +114,7 @@ mod tests {
 
     #[test]
     fn pack_unpack() {
-        let ss0: Subspace = (1,).into();
+        let ss0: Subspace = 1.into();
         let tup = (2, 3);
 
         let packed = ss0.pack(&tup);
@@ -131,8 +129,8 @@ mod tests {
 
     #[test]
     fn is_start_of() {
-        let ss0: Subspace = (1,).into();
-        let ss1: Subspace = (2,).into();
+        let ss0: Subspace = 1.into();
+        let ss1: Subspace = 2.into();
         let tup = (2, 3);
 
         assert!(ss0.is_start_of(&ss0.pack(&tup)));
@@ -140,14 +138,13 @@ mod tests {
         assert!(Subspace::from("start").is_start_of(&"start".to_vec()));
         assert!(Subspace::from("start").is_start_of(&"start".to_string().to_vec()));
         assert!(!Subspace::from("start").is_start_of(&"starting".to_vec()));
-        assert!(Subspace::from(("start",)).is_start_of(&"start".to_vec()));
         assert!(Subspace::from("start").is_start_of(&("start", "end").to_vec()));
         assert!(Subspace::from(("start", 42)).is_start_of(&("start", 42, "end").to_vec()));
     }
 
     #[test]
     fn unpack_malformed() {
-        let ss0: Subspace = ((),).into();
+        let ss0: Subspace = ((), ()).into();
 
         let malformed = {
             let mut v = ss0.bytes().to_vec();
@@ -160,7 +157,7 @@ mod tests {
 
     #[test]
     fn range() {
-        let ss: Subspace = (1,).into();
+        let ss: Subspace = 1.into();
         let tup = (2, 3);
         let packed = ss.pack(&tup);
 

--- a/foundationdb/src/tuple/element.rs
+++ b/foundationdb/src/tuple/element.rs
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn test_option() {
-        assert_eq!(&Some(42_i64).encode_to_vec(), &[21, 42]);
-        assert_eq!(&None::<i64>.encode_to_vec(), &[0]);
+        assert_eq!(&Some(42_i64).to_vec(), &[21, 42]);
+        assert_eq!(&None::<i64>.to_vec(), &[0]);
     }
 }

--- a/foundationdb/src/tuple/element.rs
+++ b/foundationdb/src/tuple/element.rs
@@ -158,13 +158,13 @@ impl Type for u8 {
 }
 
 impl<'a, T: Encode> Encode for &'a T {
-    fn encode<W: Write>(&self, w: &mut W, in_tuple: bool) -> std::io::Result<()> {
-        T::encode(self, w, in_tuple)
+    fn encode<W: Write>(&self, w: &mut W, tuple_depth: usize) -> std::io::Result<()> {
+        T::encode(self, w, tuple_depth)
     }
 }
 
 impl Encode for bool {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         if *self {
             TRUE.write(w)
         } else {
@@ -174,7 +174,7 @@ impl Encode for bool {
 }
 
 impl Decode for bool {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.is_empty() {
             return Err(Error::EOF);
         }
@@ -188,13 +188,13 @@ impl Decode for bool {
 }
 
 impl Encode for () {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         NIL.write(w)
     }
 }
 
 impl Decode for () {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.is_empty() {
             return Err(Error::EOF);
         }
@@ -206,7 +206,7 @@ impl Decode for () {
 
 #[cfg(feature = "uuid")]
 impl Encode for Uuid {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         UUID.write(w)?;
         w.write_all(self.as_bytes())
     }
@@ -214,7 +214,7 @@ impl Encode for Uuid {
 
 #[cfg(feature = "uuid")]
 impl Decode for Uuid {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.len() < 17 {
             return Err(Error::EOF);
         }
@@ -229,21 +229,21 @@ impl Decode for Uuid {
 }
 
 impl<'a> Encode for &'a str {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         STRING.write(w)?;
         encode_bytes(w, self.as_bytes())
     }
 }
 
 impl Encode for String {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         STRING.write(w)?;
         encode_bytes(w, self.as_bytes())
     }
 }
 
 impl Decode for String {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.len() < 2 {
             return Err(Error::EOF);
         }
@@ -256,8 +256,8 @@ impl Decode for String {
 }
 
 impl Encode for Vec<Element> {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
-        // TODO: should this only write the Nested markers in the case of in_tuple?
+    fn encode<W: Write>(&self, w: &mut W, tuple_depth: usize) -> std::io::Result<()> {
+        // TODO: should this only write the Nested markers in the case of tuple_depth?
         NESTED.write(w)?;
         for v in self {
             match v {
@@ -268,7 +268,7 @@ impl Encode for Vec<Element> {
                     ESCAPE.write(w)?;
                 }
                 v => {
-                    v.encode(w, true)?;
+                    v.encode(w, tuple_depth + 1)?;
                 }
             }
         }
@@ -277,12 +277,12 @@ impl Encode for Vec<Element> {
 }
 
 impl Decode for Vec<Element> {
-    fn decode(mut buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(mut buf: &[u8], tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.len() < 2 {
             return Err(Error::EOF);
         }
 
-        // TODO: should this only write the Nested markers in the case of in_tuple?
+        // TODO: should this only write the Nested markers in the case of tuple_depth?
         NESTED.expect(buf[0])?;
         let len = buf.len();
         buf = &buf[1..];
@@ -306,7 +306,7 @@ impl Decode for Vec<Element> {
                 break;
             }
 
-            let (tuple, offset) = Element::decode(buf, true)?;
+            let (tuple, offset) = Element::decode(buf, tuple_depth + 1)?;
             tuples.push(tuple);
             buf = &buf[offset..];
         }
@@ -317,21 +317,21 @@ impl Decode for Vec<Element> {
 }
 
 impl<'a> Encode for &'a [u8] {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         BYTES.write(w)?;
         encode_bytes(w, self)
     }
 }
 
 impl Encode for Vec<u8> {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         BYTES.write(w)?;
         encode_bytes(w, self.as_slice())
     }
 }
 
 impl Decode for Vec<u8> {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.len() < 2 {
             return Err(Error::EOF);
         }
@@ -344,7 +344,7 @@ impl Decode for Vec<u8> {
 }
 
 impl Encode for f32 {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         FLOAT.write(w)?;
 
         let mut buf: [u8; 4] = Default::default();
@@ -356,7 +356,7 @@ impl Encode for f32 {
 }
 
 impl Decode for f32 {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.len() < 5 {
             return Err(Error::EOF);
         }
@@ -373,7 +373,7 @@ impl Decode for f32 {
 }
 
 impl Encode for f64 {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         DOUBLE.write(w)?;
 
         let mut buf: [u8; 8] = Default::default();
@@ -385,7 +385,7 @@ impl Encode for f64 {
 }
 
 impl Decode for f64 {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.len() < 9 {
             return Err(Error::EOF);
         }
@@ -402,7 +402,7 @@ impl Decode for f64 {
 }
 
 impl Encode for i64 {
-    fn encode<W: Write>(&self, w: &mut W, _in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, _tuple_depth: usize) -> std::io::Result<()> {
         let mut code = INTZERO;
         let n;
         let mut buf: [u8; 8] = Default::default();
@@ -423,7 +423,7 @@ impl Encode for i64 {
 }
 
 impl Decode for i64 {
-    fn decode(buf: &[u8], _in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], _tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.is_empty() {
             return Err(Error::EOF);
         }
@@ -461,21 +461,63 @@ impl Decode for i64 {
     }
 }
 
+impl<T> Encode for Option<T>
+where
+    T: Encode,
+{
+    fn encode<W: Write>(&self, w: &mut W, tuple_depth: usize) -> std::io::Result<()> {
+        match *self {
+            Some(ref t) => t.encode(w, tuple_depth),
+            None => {
+                // only at tuple depth greater than 1...
+                if tuple_depth > 1 {
+                    NIL.write(w)?;
+                    ESCAPE.write(w)
+                } else {
+                    NIL.write(w)
+                }
+            }
+        }
+    }
+}
+
+impl<T> Decode for Option<T>
+where
+    T: Decode,
+{
+    fn decode(buf: &[u8], tuple_depth: usize) -> Result<(Self, usize)> {
+        match buf[0] {
+            NIL => {
+                let buf = &buf[1..];
+
+                // custom escape markers are only needed in Nested tuples...
+                if tuple_depth > 1 {
+                    ESCAPE.expect(buf[0])?;
+                    Ok((None, 2))
+                } else {
+                    Ok((None, 1))
+                }
+            }
+            _ => T::decode(buf, tuple_depth).map(|(t, offset)| (Some(t), offset)),
+        }
+    }
+}
+
 impl Encode for Element {
-    fn encode<W: Write>(&self, w: &mut W, in_tuple: bool) -> std::io::Result<()> {
+    fn encode<W: Write>(&self, w: &mut W, tuple_depth: usize) -> std::io::Result<()> {
         use self::Element::*;
 
         match *self {
-            Empty => Encode::encode(&(), w, in_tuple),
-            Bytes(ref v) => Encode::encode(v, w, in_tuple),
-            String(ref v) => Encode::encode(v, w, in_tuple),
-            Tuple(ref v) => Encode::encode(&v.0, w, in_tuple),
-            I64(ref v) => Encode::encode(v, w, in_tuple),
-            F32(ref v) => Encode::encode(v, w, in_tuple),
-            F64(ref v) => Encode::encode(v, w, in_tuple),
-            Bool(ref v) => Encode::encode(v, w, in_tuple),
+            Empty => Encode::encode(&(), w, tuple_depth),
+            Bytes(ref v) => Encode::encode(v, w, tuple_depth),
+            String(ref v) => Encode::encode(v, w, tuple_depth),
+            Tuple(ref v) => Encode::encode(&v.0, w, tuple_depth),
+            I64(ref v) => Encode::encode(v, w, tuple_depth),
+            F32(ref v) => Encode::encode(v, w, tuple_depth),
+            F64(ref v) => Encode::encode(v, w, tuple_depth),
+            Bool(ref v) => Encode::encode(v, w, tuple_depth),
             #[cfg(feature = "uuid")]
-            Uuid(ref v) => Encode::encode(v, w, in_tuple),
+            Uuid(ref v) => Encode::encode(v, w, tuple_depth),
             // Ugly hack
             // We will be able to drop this once #[non_exhaustive]
             // lands on `stable`
@@ -485,7 +527,7 @@ impl Encode for Element {
 }
 
 impl Decode for Element {
-    fn decode(buf: &[u8], in_tuple: bool) -> Result<(Self, usize)> {
+    fn decode(buf: &[u8], tuple_depth: usize) -> Result<(Self, usize)> {
         if buf.is_empty() {
             return Err(Error::EOF);
         }
@@ -494,35 +536,35 @@ impl Decode for Element {
         match code {
             NIL => Ok((Element::Empty, 1)),
             BYTES => {
-                let (v, offset) = Decode::decode(buf, in_tuple)?;
+                let (v, offset) = Decode::decode(buf, tuple_depth)?;
                 Ok((Element::Bytes(v), offset))
             }
             STRING => {
-                let (v, offset) = Decode::decode(buf, in_tuple)?;
+                let (v, offset) = Decode::decode(buf, tuple_depth)?;
                 Ok((Element::String(v), offset))
             }
             FLOAT => {
-                let (v, offset) = Decode::decode(buf, in_tuple)?;
+                let (v, offset) = Decode::decode(buf, tuple_depth)?;
                 Ok((Element::F32(v), offset))
             }
             DOUBLE => {
-                let (v, offset) = Decode::decode(buf, in_tuple)?;
+                let (v, offset) = Decode::decode(buf, tuple_depth)?;
                 Ok((Element::F64(v), offset))
             }
             FALSE => Ok((Element::Bool(false), 1)),
             TRUE => Ok((Element::Bool(false), 1)),
             #[cfg(feature = "uuid")]
             UUID => {
-                let (v, offset) = Decode::decode(buf, in_tuple)?;
+                let (v, offset) = Decode::decode(buf, tuple_depth)?;
                 Ok((Element::Uuid(v), offset))
             }
             NESTED => {
-                let (v, offset) = Decode::decode(buf, in_tuple)?;
+                let (v, offset) = Decode::decode(buf, tuple_depth)?;
                 Ok((Element::Tuple(Tuple(v)), offset))
             }
             val => {
                 if val >= NEGINTSTART && val <= POSINTEND {
-                    let (v, offset) = Decode::decode(buf, in_tuple)?;
+                    let (v, offset) = Decode::decode(buf, tuple_depth)?;
                     Ok((Element::I64(v), offset))
                 } else {
                     //TODO: Versionstamp, ...
@@ -627,10 +669,16 @@ mod tests {
     fn test_decode_nested() {
         use tuple::Decode;
 
-        assert!(Tuple::decode(&[NESTED], false).is_err());
-        assert!(Tuple::decode(&[NESTED, NIL], false).is_ok());
-        assert!(Tuple::decode(&[NESTED, INTZERO], false).is_err());
-        assert!(Tuple::decode(&[NESTED, NIL, NESTED, NIL], false).is_ok());
-        assert!(Tuple::decode(&[NESTED, NESTED, NESTED, NIL, NIL, NIL], false).is_ok());
+        assert!(Tuple::decode(&[NESTED], 0).is_err());
+        assert!(Tuple::decode(&[NESTED, NIL], 0).is_ok());
+        assert!(Tuple::decode(&[NESTED, INTZERO], 0).is_err());
+        assert!(Tuple::decode(&[NESTED, NIL, NESTED, NIL], 0).is_ok());
+        assert!(Tuple::decode(&[NESTED, NESTED, NESTED, NIL, NIL, NIL], 0).is_ok());
+    }
+
+    #[test]
+    fn test_option() {
+        assert_eq!(&Some(42_i64).encode_to_vec(), &[21, 42]);
+        assert_eq!(&None::<i64>.encode_to_vec(), &[0]);
     }
 }

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -249,7 +249,10 @@ mod tests {
     fn test_eq() {
         assert_eq!("string".to_vec(), "string".to_string().to_vec());
 
-        assert_eq!("string".to_vec(), ("string",).to_vec());
+        assert_eq!(
+            ("string", "string".to_string()).to_vec(),
+            ("string".to_string(), "string").to_vec()
+        );
     }
 
     #[test]

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -15,7 +15,6 @@ use std::{self, io::Write, string::FromUtf8Error};
 
 pub use self::element::Element;
 use self::element::Type;
-use subspace::Subspace;
 
 /// Tuple encoding/decoding related errors
 #[derive(Debug, Fail)]
@@ -258,11 +257,11 @@ mod tests {
     #[test]
     fn test_encode_recursive_tuple() {
         assert_eq!(
-            &("one", ("two", 42)).encode_to_vec(),
+            &("one", ("two", 42)).to_vec(),
             &[2, 111, 110, 101, 0, 5, 2, 116, 119, 111, 0, 21, 42, 0]
         );
         assert_eq!(
-            &("one", ("two", 42, ("three", 33))).encode_to_vec(),
+            &("one", ("two", 42, ("three", 33))).to_vec(),
             &[
                 2, 111, 110, 101, 0, 5, 2, 116, 119, 111, 0, 21, 42, 5, 2, 116, 104, 114, 101, 101,
                 0, 21, 33, 0, 0,
@@ -273,21 +272,21 @@ mod tests {
         // from Python impl:
         //  >>> [ord(x) for x in fdb.tuple.pack( (None, (None, None)) )]
         assert_eq!(
-            &(None::<i64>, (None::<i64>, None::<i64>)).encode_to_vec(),
+            &(None::<i64>, (None::<i64>, None::<i64>)).to_vec(),
             &[0, 5, 0, 255, 0, 255, 0]
         )
     }
 
     #[test]
     fn test_decode_recursive_tuple() {
-        let two_decode = <(String, (String, i64))>::decode_full(&[
+        let two_decode = <(String, (String, i64))>::try_from(&[
             2, 111, 110, 101, 0, 5, 2, 116, 119, 111, 0, 21, 42, 0,
         ]).expect("failed two");
 
         // TODO: can we get eq for borrows of the inner types?
         assert_eq!(("one".to_string(), ("two".to_string(), 42)), two_decode);
 
-        let three_decode = <(String, (String, i64, (String, i64)))>::decode_full(&[
+        let three_decode = <(String, (String, i64, (String, i64)))>::try_from(&[
             2, 111, 110, 101, 0, 5, 2, 116, 119, 111, 0, 21, 42, 5, 2, 116, 104, 114, 101, 101, 0,
             21, 33, 0, 0,
         ]).expect("failed three");
@@ -303,7 +302,7 @@ mod tests {
         //
         // from Python impl:
         //  >>> [ord(x) for x in fdb.tuple.pack( (None, (None, None)) )]
-        let option_decode = <(Option<i64>, (Option<i64>, Option<i64>))>::decode_full(&[
+        let option_decode = <(Option<i64>, (Option<i64>, Option<i64>))>::try_from(&[
             0, 5, 0, 255, 0, 255, 0,
         ]).expect("failed option");
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -163,7 +163,6 @@ macro_rules! tuple_impls {
 }
 
 tuple_impls! {
-    1 => (0 T0)
     2 => (0 T0 1 T1)
     3 => (0 T0 1 T1 2 T2)
     4 => (0 T0 1 T1 2 T2 3 T3)

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -212,13 +212,13 @@ mod tests {
 
     #[test]
     fn test_malformed_int() {
-        assert!(Tuple::decode(&[21, 0], 0).is_ok());
-        assert!(Tuple::decode(&[22, 0], 0).is_err());
-        assert!(Tuple::decode(&[22, 0, 0], 0).is_ok());
+        assert!(Tuple::try_from(&[21, 0]).is_ok());
+        assert!(Tuple::try_from(&[22, 0]).is_err());
+        assert!(Tuple::try_from(&[22, 0, 0]).is_ok());
 
-        assert!(Tuple::decode(&[19, 0], 0).is_ok());
-        assert!(Tuple::decode(&[18, 0], 0).is_err());
-        assert!(Tuple::decode(&[18, 0, 0], 0).is_ok());
+        assert!(Tuple::try_from(&[19, 0]).is_ok());
+        assert!(Tuple::try_from(&[18, 0]).is_err());
+        assert!(Tuple::try_from(&[18, 0, 0]).is_ok());
     }
 
     #[test]

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -162,6 +162,7 @@ macro_rules! tuple_impls {
 }
 
 tuple_impls! {
+    1 => (0 T0)
     2 => (0 T0 1 T1)
     3 => (0 T0 1 T1 2 T2)
     4 => (0 T0 1 T1 2 T2 3 T3)
@@ -307,5 +308,54 @@ mod tests {
         ]).expect("failed option");
 
         assert_eq!(&(None::<i64>, (None::<i64>, None::<i64>)), &option_decode)
+    }
+
+    #[test]
+    fn test_single_tuple_encode() {
+        // derived from python impl
+        assert_eq!(&(1,).to_vec(), &1.to_vec());
+
+        // >>> [ord(x) for x in fdb.tuple.pack((1,(1,)))]
+        // [21, 1, 5, 21, 1, 0]
+        assert_eq!(&(1, (1,)).to_vec(), &[21, 1, 5, 21, 1, 0]);
+
+        // >>> [ord(x) for x in fdb.tuple.pack( (1,(1,(1,))) )]
+        // [21, 1, 5, 21, 1, 5, 21, 1, 0, 0]
+        assert_eq!(&(1, (1, (1,))).to_vec(), &[21, 1, 5, 21, 1, 5, 21, 1, 0, 0]);
+
+        // >>> [ord(x) for x in fdb.tuple.pack( (1,(1,),(1,)) )]
+        // [21, 1, 5, 21, 1, 0, 5, 21, 1, 0]
+        assert_eq!(
+            &(1, (1,), (1,)).to_vec(),
+            &[21, 1, 5, 21, 1, 0, 5, 21, 1, 0]
+        );
+    }
+
+    #[test]
+    fn test_single_tuple_decode() {
+        // derived from python impl
+        assert_eq!(1_i64, Decode::try_from(&[21, 1]).expect("1"));
+        assert_eq!((1_i64,), Decode::try_from(&[21, 1]).expect("(1,)"));
+
+        // >>> [ord(x) for x in fdb.tuple.pack((1,(1,)))]
+        // [21, 1, 5, 21, 1, 0]
+        assert_eq!(
+            (1_i64, (1_i64,)),
+            Decode::try_from(&[21, 1, 5, 21, 1, 0]).expect("(1, (1,))")
+        );
+
+        // >>> [ord(x) for x in fdb.tuple.pack( (1,(1,(1,))) )]
+        // [21, 1, 5, 21, 1, 5, 21, 1, 0, 0]
+        assert_eq!(
+            (1_i64, (1_i64, (1_i64,))),
+            Decode::try_from(&[21, 1, 5, 21, 1, 5, 21, 1, 0, 0]).expect("(1, (1, (1,)))")
+        );
+
+        // >>> [ord(x) for x in fdb.tuple.pack( (1,(1,),(1,)) )]
+        // [21, 1, 5, 21, 1, 0, 5, 21, 1, 0]
+        assert_eq!(
+            (1_i64, (1_i64,), (1_i64,)),
+            Decode::try_from(&[21, 1, 5, 21, 1, 0, 5, 21, 1, 0]).expect("(1, (1,), (1,))")
+        );
     }
 }


### PR DESCRIPTION
Fixes: #49 

This resurrects and corrects the tests for recursive tuples. It's not a super elegant solution, but I think is correct.

- adds `tuple_depth: usize` to encode and decode
- adds `Option` encode/decode with tuple encoding edge case test