### PR TITLE
Add futures to docs

### DIFF
--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -36,6 +36,7 @@
 //! ```toml
 //! [dependencies]
 //! foundationdb = "*"
+//! futures = "0.1"
 //! ```
 //!
 //! ## Extern the crate in `bin.rs` or `lib.rs`


### PR DESCRIPTION
This is the same as the fix in README with https://github.com/bluejekyll/foundationdb-rs/pull/88/commits/1ca2f423e03298de723ce29a232fffd93147ab10 and will be useful for people who use docs instead of README