### PR TITLE
Cleanup the fdb version features from primary crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,11 +59,11 @@ before_install:
   - if [[ "$CLIPPY" == "true" ]]; then cargo install clippy --force ; fi
 
 script:
-  - cargo test -p foundationdb-sys
-  - cargo test -p foundationdb-gen
-  - cargo test -p foundationdb
-  - cd foundationdb && cargo test --no-default-features --features fdb-6_0
-  - cargo test -p foundationdb-bench
-  - cargo run -p foundationdb --example class-scheduling
+  - cargo test --manifest-path foundationdb-sys/Cargo.toml
+  - cargo test --manifest-path foundationdb-gen/Cargo.toml
+  - cargo test --manifest-path foundationdb/Cargo.toml
+  - cargo test --manifest-path foundationdb/Cargo.toml --no-default-features --features fdb-6_0
+  - cargo test --manifest-path foundationdb-bench/Cargo.toml
+  - cargo run --manifest-path foundationdb/Cargo.toml --example class-scheduling
 
 # after_success: cargo kcov here...

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,10 @@ before_install:
 
 script:
   - cargo test -p foundationdb-sys
-  - cargo test -p foundationdb-gen --all-features
-  - cargo test -p foundationdb --all-features
-  - cargo test -p foundationdb-bench --all-features
-  - cargo run -p foundationdb --example class-scheduling --all-features 
+  - cargo test -p foundationdb-gen
+  - cargo test -p foundationdb
+  - cd foundationdb && cargo test --no-default-features --features fdb-6_0
+  - cargo test -p foundationdb-bench
+  - cargo run -p foundationdb --example class-scheduling
 
 # after_success: cargo kcov here...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ install:
 
 build_script:
   - cargo test -p foundationdb-sys
-  - cargo test -p foundationdb-gen --all-features
-  - cargo test -p foundationdb --all-features
-  - cargo test -p foundationdb-bench --all-features
-  - cargo run -p foundationdb --example class-scheduling --all-features 
+  - cargo test -p foundationdb-gen
+  - cargo test -p foundationdb
+  - cd foundationdb && cargo test --no-default-features --features fdb-6_0
+  - cargo test -p foundationdb-bench
+  - cargo run -p foundationdb --example class-scheduling

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ install:
   - ps: $env:Path = "C:\Program Files\foundationdb\bin;$env:USERPROFILE\.cargo\bin;$env:Path"
 
 build_script:
-  - cargo test -p foundationdb-sys
-  - cargo test -p foundationdb-gen
-  - cargo test -p foundationdb
-  - cd foundationdb && cargo test --no-default-features --features fdb-6_0
-  - cargo test -p foundationdb-bench
-  - cargo run -p foundationdb --example class-scheduling
+  - cargo test --manifest-path foundationdb-sys/Cargo.toml
+  - cargo test --manifest-path foundationdb-gen/Cargo.toml
+  - cargo test --manifest-path foundationdb/Cargo.toml
+  - cargo test --manifest-path foundationdb/Cargo.toml --no-default-features --features fdb-6_0
+  - cargo test --manifest-path foundationdb-bench/Cargo.toml
+  - cargo run --manifest-path foundationdb/Cargo.toml --example class-scheduling

--- a/foundationdb-gen/Cargo.toml
+++ b/foundationdb-gen/Cargo.toml
@@ -3,6 +3,21 @@ name = "foundationdb-gen"
 version = "0.1.0"
 authors = ["Jihyun Yu <yjh0502@gmail.com>"]
 
+description = """
+Binding generation helper for FoundationDB.
+"""
+
+documentation = "https://docs.rs/foundationdb"
+repository = "https://github.com/bluejekyll/foundationdb-rs"
+license = "MIT/Apache-2.0"
+
+readme = "README.md"
+keywords = ["foundationdb", "kv"]
+categories = ["database"]
+
+[badges]
+travis-ci = { repository = "bluejekyll/foundationdb-rs" }
+
 [dependencies]
 failure = "0.1"
 Inflector = "0.11"

--- a/foundationdb-gen/README.md
+++ b/foundationdb-gen/README.md
@@ -1,0 +1,4 @@
+
+# FoundationDB generator
+
+This is a helper for generating the FoundationDB bindings used by the [foundationdb](https://crates.io/crates/foundationdb) crate.

--- a/foundationdb-sys/build.rs
+++ b/foundationdb-sys/build.rs
@@ -30,12 +30,20 @@ fn main() {
     // to the driver and then '#define FDB_API_VERSION FDB_TRICKY_VERSION', but
     // bindgen isn't smart enough to resolve that from the arguments. Instead, write
     // out a src/wrapper.h file with the chosen version instead.
+    let api_version;
+
     #[cfg(feature = "fdb-5_1")]
-    let api_version = 510;
+    {
+        api_version = 510;
+    }
     #[cfg(feature = "fdb-5_2")]
-    let api_version = 520;
+    {
+        api_version = 520;
+    }
     #[cfg(feature = "fdb-6_0")]
-    let api_version = 600;
+    {
+        api_version = 600;
+    }
 
     // Sigh, bindgen only takes a String for its header path, but that's UTF-8 while
     // PathBuf is OS-native...

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -20,7 +20,11 @@ travis-ci = { repository = "bluejekyll/foundationdb-rs" }
 # codecov = { repository = "bluejekyll/foundationdb-rs", branch = "master", service = "github" }
 
 [features]
-default = ["uuid"]
+default = ["fdb-6_0", "uuid"]
+
+fdb-5_1 = [ "foundationdb-sys/fdb-5_1" ]
+fdb-5_2 = [ "foundationdb-sys/fdb-5_2" ]
+fdb-6_0 = [ "foundationdb-sys/fdb-6_0" ]
 
 [build-dependencies]
 foundationdb-gen = { version = "0.1.0", path = "../foundationdb-gen" }
@@ -28,7 +32,7 @@ foundationdb-gen = { version = "0.1.0", path = "../foundationdb-gen" }
 [dependencies]
 failure = "0.1"
 failure_derive = "0.1"
-foundationdb-sys = { version = "0.2.0", path = "../foundationdb-sys" }
+foundationdb-sys = { version = "0.2.0", path = "../foundationdb-sys", default-features = false }
 futures = "0.1"
 lazy_static = "1.0"
 byteorder = "1.2"


### PR DESCRIPTION
There was no decent way to select FDB versions from the primary crate.
  this disables all features in the sys crate from the fdb crate,
  and clones all the feature names to make it possible to enable
  each as necessary.