### PR TITLE
Mark FdbFuture as Send + Sync

### DIFF
--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -30,4 +30,4 @@ fdb-6_0 = [ ]
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.50"
+bindgen = "0.51"

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -39,6 +39,7 @@ byteorder = "1.2"
 log = "0.4"
 uuid = { version = "0.7", optional = true }
 rand = "0.7.0"
+static_assertions = "1.1"
 
 [dev-dependencies]
 rand = "0.7"

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -81,6 +81,9 @@ impl futures::Future for FdbFuture {
     }
 }
 
+unsafe impl Send for FdbFuture {}
+unsafe impl Sync for FdbFuture {}
+
 // The callback from fdb C API can be called from multiple threads. so this callback should be
 // thread-safe.
 extern "C" fn fdb_future_callback(

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -121,6 +121,8 @@ extern crate futures;
 extern crate core;
 extern crate lazy_static;
 extern crate rand;
+#[macro_use]
+extern crate static_assertions;
 #[cfg(feature = "uuid")]
 extern crate uuid;
 

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -1038,3 +1038,8 @@ impl Future for TrxFuture {
         }
     }
 }
+
+#[allow(unused)]
+fn test_futures_are_send_sync() {
+    assert_impl_all!(TrxCommit: Send, Sync);
+}


### PR DESCRIPTION
The primary motivation here is to make the transaction commit future compatible with Tokio. Tokio requires all futures spawned on its executor to be `Send`. I added the `Sync` as well since the two tend to go together.

From reading the docs and inspecting the code, I see no reason that the future cannot be safely sent between threads. The only method on the struct can only be called from one thread at a time, so the struct should be implicitly `Sync`.

The dependency on `static_assertions` is not strictly required, but it does make asserting the trait implementations I care about easier.