### PR TITLE
Fix comment for `GetKeyResult`

### DIFF
--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -665,7 +665,7 @@ impl GetKeyResult {
         self.trx.clone()
     }
 
-    /// Returns the values associated with this get
+    /// Returns the key associated with the call to `Transaction::get_key`
     pub fn value(&self) -> &[u8] {
         self.inner.get_key().expect("inner should resolve into key")
     }


### PR DESCRIPTION
The prior comment was unclear that the result of calling `value()` was the key that was found by the `KeySelector`. I didn't realize what that method did until reading the code. I was assuming that the output of `value()` would be the value associated with the located key.

Personally, I would be tempted to change the name of the method to `key()` to avoid confusion with the value associated with the key. Regardless of making that backwards incompatible change, this comment should make it easier to use.