### PR TITLE
Make the various result types Send/Sync

### DIFF
--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -149,6 +149,9 @@ impl Drop for FdbFutureResult {
     }
 }
 
+unsafe impl Send for FdbFutureResult {}
+unsafe impl Sync for FdbFutureResult {}
+
 impl FdbFutureResult {
     pub(crate) fn new(f: *mut fdb::FDBFuture) -> Self {
         Self { f }

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -1042,4 +1042,21 @@ impl Future for TrxFuture {
 #[allow(unused)]
 fn test_futures_are_send_sync() {
     assert_impl_all!(TrxCommit: Send, Sync);
+    assert_impl_all!(TrxErrFuture: Send, Sync);
+    assert_impl_all!(TrxGet: Send, Sync);
+    assert_impl_all!(TrxGetAddressesForKey: Send, Sync);
+    assert_impl_all!(TrxGetKey: Send, Sync);
+    assert_impl_all!(TrxGetRange: Send, Sync);
+    assert_impl_all!(TrxReadVersion: Send, Sync);
+    assert_impl_all!(TrxVersionstamp: Send, Sync);
+    assert_impl_all!(TrxWatch: Send, Sync);
+}
+
+#[allow(unused)]
+fn test_results_are_send_sync() {
+    assert_impl_all!(GetAddressResult: Send, Sync);
+    assert_impl_all!(GetKeyResult: Send, Sync);
+    assert_impl_all!(GetRangeResult: Send, Sync);
+    assert_impl_all!(GetResult: Send, Sync);
+    assert_impl_all!(RangeStream: Send, Sync);
 }


### PR DESCRIPTION
Related to #145. This change marks the FDBResult type as Send/Sync and asserts that all of the transaction result types are thus Send/Sync. The FDB C API is thread safe, so this change should be safe.